### PR TITLE
Add case information response object

### DIFF
--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
+{
+    public class CaseNoteInformation
+    {
+
+        public string MosaicId { get; set; }
+
+        public int CaseNoteId { get; set; }
+
+        public int PersonVisitId { get; set; }
+
+        public string NoteType { get; set; }
+
+        public string CaseNoteTitle { get; set; }
+
+        public DateTime EffectiveDate { get; set; }
+
+        public DateTime CreatedOn { get; set; }
+
+        public string CreatedBy { get; set; }
+
+        public string LastUpdatedBy { get; set; }
+
+        public DateTime LastUpdatedOn { get; set; }
+
+        public string CaseNoteContent { get; set; }
+
+
+
+        //id                                       numeric(9)  not null,
+        //person_id                                numeric(9)  not null,
+        // SKIP episode_id                               numeric(9),
+        //person_visit_id                          numeric(9),
+        //note_type                                varchar(16) not null,
+        //title                                    varchar(100),
+        //effective_date                           timestamp,
+        //created_on                               timestamp,
+        //created_by                               varchar(30),
+        //last_updated_by                          varchar(64),
+        //last_updated_on                          timestamp,
+        //frozen_flag                              varchar(1),
+        //note                                     text,
+        root_case_note                           numeric(9),
+        // SKIP created_acting_for                       varchar(30),
+        // SKIP updated_acting_for                       varchar(30),
+        // SKIP significant_event_flag                   varchar(1),
+        completed_date                           timestamp,
+            timeout_date                             timestamp,
+        state                                    varchar(16) not null,
+        copy_of_case_note_id                     numeric(9),
+        copied_by                                varchar(30),
+        copied_acting_for                        varchar(30),
+        copied_date                              timestamp,
+            message_sent_acting_for                  varchar(30),
+        message_sent_by                          varchar(30),
+        message_sent_datetime                    timestamp,
+            message_text                             varchar(4000),
+
+
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
@@ -4,42 +4,42 @@ namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 {
     public class CaseNoteInformation
     {
-
         public string MosaicId { get; set; }
 
         public int CaseNoteId { get; set; }
 
-        // public int PersonVisitId { get; set; }
+        public int PersonVisitId { get; set; }
 
         public string NoteType { get; set; }
 
-        // public string CaseNoteTitle { get; set; }
+        public string CaseNoteTitle { get; set; }
 
-        // public DateTime EffectiveDate { get; set; }
+        public DateTime EffectiveDate { get; set; }
 
         public DateTime CreatedOn { get; set; }
+
         public DateTime LastUpdatedOn { get; set; }
 
-// Hopefully one of these will not be NULL
         public string CreatedByName { get; set; }
+
         public string CreatedByEmail { get; set; }
 
-        // public string LastUpdatedName { get; set; }
-        // public string LastUpdatedEmail { get; set; }
+        public string LastUpdatedName { get; set; }
 
+        public string LastUpdatedEmail { get; set; }
 
-        // public string CaseNoteContent { get; set; }
+        public string CaseNoteContent { get; set; }
 
-        // public int RootCaseNoteId { get; set; }
+        public int RootCaseNoteId { get; set; }
 
-        // public DateTime CompletedDate { get; set; }
+        public DateTime CompletedDate { get; set; }
 
-        // public DateTime TimeoutDate { get; set; }
+        public DateTime TimeoutDate { get; set; }
 
-        // public int CopyOfCaseNoteId { get; set; }
+        public int CopyOfCaseNoteId { get; set; }
 
-        // public string CopiedBy { get; set; }
+        public string CopiedBy { get; set; }
 
-        // public DateTime CopiedDate { get; set; }
+        public DateTime CopiedDate { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
@@ -9,55 +9,37 @@ namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 
         public int CaseNoteId { get; set; }
 
-        public int PersonVisitId { get; set; }
+        // public int PersonVisitId { get; set; }
 
         public string NoteType { get; set; }
 
-        public string CaseNoteTitle { get; set; }
+        // public string CaseNoteTitle { get; set; }
 
-        public DateTime EffectiveDate { get; set; }
+        // public DateTime EffectiveDate { get; set; }
 
         public DateTime CreatedOn { get; set; }
-
-        public string CreatedBy { get; set; }
-
-        public string LastUpdatedBy { get; set; }
-
         public DateTime LastUpdatedOn { get; set; }
 
-        public string CaseNoteContent { get; set; }
+// Hopefully one of these will not be NULL
+        public string CreatedByName { get; set; }
+        public string CreatedByEmail { get; set; }
+
+        // public string LastUpdatedName { get; set; }
+        // public string LastUpdatedEmail { get; set; }
 
 
+        // public string CaseNoteContent { get; set; }
 
-        //id                                       numeric(9)  not null,
-        //person_id                                numeric(9)  not null,
-        // SKIP episode_id                               numeric(9),
-        //person_visit_id                          numeric(9),
-        //note_type                                varchar(16) not null,
-        //title                                    varchar(100),
-        //effective_date                           timestamp,
-        //created_on                               timestamp,
-        //created_by                               varchar(30),
-        //last_updated_by                          varchar(64),
-        //last_updated_on                          timestamp,
-        //frozen_flag                              varchar(1),
-        //note                                     text,
-        root_case_note                           numeric(9),
-        // SKIP created_acting_for                       varchar(30),
-        // SKIP updated_acting_for                       varchar(30),
-        // SKIP significant_event_flag                   varchar(1),
-        completed_date                           timestamp,
-            timeout_date                             timestamp,
-        state                                    varchar(16) not null,
-        copy_of_case_note_id                     numeric(9),
-        copied_by                                varchar(30),
-        copied_acting_for                        varchar(30),
-        copied_date                              timestamp,
-            message_sent_acting_for                  varchar(30),
-        message_sent_by                          varchar(30),
-        message_sent_datetime                    timestamp,
-            message_text                             varchar(4000),
+        // public int RootCaseNoteId { get; set; }
 
+        // public DateTime CompletedDate { get; set; }
 
+        // public DateTime TimeoutDate { get; set; }
+
+        // public int CopyOfCaseNoteId { get; set; }
+
+        // public string CopiedBy { get; set; }
+
+        // public DateTime CopiedDate { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformationList.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformationList.cs
@@ -1,9 +1,9 @@
+using System.Collections.Generic;
+
 namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 {
     public class CaseNoteInformationList
     {
         public List<CaseNoteInformation> CaseNotes { get; set; }
-
-        public string NextCursor { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformationList.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformationList.cs
@@ -1,0 +1,9 @@
+namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
+{
+    public class CaseNoteInformationList
+    {
+        public List<CaseNoteInformation> CaseNotes { get; set; }
+
+        public string NextCursor { get; set; }
+    }
+}


### PR DESCRIPTION
* This adds a response object for case note information
* Depending on which endpoint is called, not all fields will be populated.
* For the list endpoint, only the fields needed to display information on the Records History page will have values.
* For the view details endpoints, fields needed to display detailed information for a specific case note will have values.

Any suggestions/feedback would be appreciated.