### PR TITLE
Add migration to add workers table

### DIFF
--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210316113842_AddWorkersTable.Designer.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210316113842_AddWorkersTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
@@ -9,9 +10,10 @@ using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations
 {
     [DbContext(typeof(SocialCareContext))]
-    partial class SocialCareContextModelSnapshot : ModelSnapshot
+    [Migration("20210316113842_AddWorkersTable")]
+    partial class AddWorkersTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210316113842_AddWorkersTable.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210316113842_AddWorkersTable.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations
+{
+    public partial class AddWorkersTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "workers",
+                schema: "dbo",
+                columns: table => new
+                {
+                    id = table.Column<long>(type: "bigint", maxLength: 9, nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    first_names = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: true),
+                    last_names = table.Column<string>(type: "character varying(30)", maxLength: 30, nullable: true),
+                    system_user_id = table.Column<string>(type: "character varying(64)", maxLength: 64, nullable: true),
+                    email_address = table.Column<string>(type: "character varying(240)", maxLength: 240, nullable: true),
+                    accessible = table.Column<string>(type: "character varying(1)", maxLength: 1, nullable: true),
+                    context_code = table.Column<string>(type: "character varying(1)", maxLength: 1, nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_workers", x => x.id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "workers",
+                schema: "dbo");
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/SocialCareContext.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/SocialCareContext.cs
@@ -14,6 +14,8 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
 
         public DbSet<NoteType> NoteTypes { get; set; }
 
+        public DbSet<Worker> Workers { get; set; }
+
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
             // composite primary key for TelephoneNumber table

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Worker.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Worker.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
+{
+    [Table("workers", Schema = "dbo")]
+    public class Worker
+    {
+        [Column("id")]
+        [MaxLength(9)]
+        [Key]
+        public long Id { get; set; }
+
+        [Column("first_names")]
+        [MaxLength(30)]
+        public string FirstNames { get; set; }
+
+        [Column("last_names")]
+        [MaxLength(30)]
+        public string LastNames { get; set; }
+
+        [Column("system_user_id")]
+        [MaxLength(64)]
+        public string SystemUserId { get; set; }
+
+        [Column("email_address")]
+        [MaxLength(240)]
+        public string EmailAddress { get; set; }
+
+        [Column("accessible")]
+        [MaxLength(1)]
+        public string Accessible { get; set; }
+
+        [Column("context_code")]
+        [MaxLength(1)]
+        public string ContextCode { get; set; }
+    }
+}


### PR DESCRIPTION
The Workers table is required for the following attributes for getting case notes:

- CreatedByName
- CreatedByEmail
- LastUpdatedName
- LastUpdatedEmail
- CopiedBy

This PR adds a migration to add a `Workers` table. NB: `accessible` and `context_code` were only added because they can't be left `null` according to the DDL of the `WORKERS` table.