### PR TITLE
Add usecase for list case note endpoints

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using FluentAssertions;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
@@ -5,8 +6,10 @@ using ResidentsSocialCarePlatformApi.V1.Domain;
 using ResidentsSocialCarePlatformApi.V1.Factories;
 using NUnit.Framework;
 using Address = ResidentsSocialCarePlatformApi.V1.Domain.Address;
+using CaseNoteInformation = ResidentsSocialCarePlatformApi.V1.Domain.CaseNoteInformation;
 using ResidentInformation = ResidentsSocialCarePlatformApi.V1.Domain.ResidentInformation;
 using ResidentInformationResponse = ResidentsSocialCarePlatformApi.V1.Boundary.Responses.ResidentInformation;
+using CaseNoteInformationResponse = ResidentsSocialCarePlatformApi.V1.Boundary.Responses.CaseNoteInformation;
 
 namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
 {
@@ -70,6 +73,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                 },
                 Restricted = "N"
             };
+
             domain.ToResponse().Should().BeEquivalentTo(expectedResponse);
         }
 
@@ -99,6 +103,60 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                 PhoneNumber = null,
                 Restricted = null
             };
+
+            domain.ToResponse().Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
+        public void CanMapSummarisedCaseNoteInformationFromDomainToResponse()
+        {
+            var recordOneTime = new DateTime();
+            var recordTwoTime = new DateTime();
+
+            var domain = new List<CaseNoteInformation>
+            {
+                new CaseNoteInformation
+                {
+                    MosaicId = "12345",
+                    CaseNoteId = 67890,
+                    CaseNoteTitle = "I AM A CASE NOTE",
+                    EffectiveDate = recordOneTime,
+                    CreatedOn = recordOneTime,
+                    LastUpdatedOn = recordOneTime
+                },
+                new CaseNoteInformation
+                {
+                    MosaicId = "000000",
+                    CaseNoteId = 11111222,
+                    CaseNoteTitle = "I AM ANOTHER CASE NOTE",
+                    EffectiveDate = recordTwoTime,
+                    CreatedOn = recordTwoTime,
+                    LastUpdatedOn = recordTwoTime
+                }
+            };
+
+            var expectedResponse = new List<CaseNoteInformationResponse>
+            {
+                new CaseNoteInformationResponse
+                {
+                    MosaicId = "12345",
+                    CaseNoteId = 67890,
+                    CaseNoteTitle = "I AM A CASE NOTE",
+                    EffectiveDate = recordOneTime,
+                    CreatedOn = recordOneTime,
+                    LastUpdatedOn = recordOneTime
+                },
+                new CaseNoteInformationResponse
+                {
+                    MosaicId = "000000",
+                    CaseNoteId = 11111222,
+                    CaseNoteTitle = "I AM ANOTHER CASE NOTE",
+                    EffectiveDate = recordTwoTime,
+                    CreatedOn = recordTwoTime,
+                    LastUpdatedOn = recordTwoTime
+                }
+            };
+
             domain.ToResponse().Should().BeEquivalentTo(expectedResponse);
         }
     }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllCaseNotesUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllCaseNotesUseCaseTests.cs
@@ -1,0 +1,45 @@
+using System.Linq;
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
+using ResidentsSocialCarePlatformApi.V1.Factories;
+using ResidentsSocialCarePlatformApi.V1.Gateways;
+using ResidentsSocialCarePlatformApi.V1.UseCase;
+using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.V1.Domain;
+using ResidentInformation = ResidentsSocialCarePlatformApi.V1.Domain.ResidentInformation;
+using ResidentInformationResponse = ResidentsSocialCarePlatformApi.V1.Boundary.Responses.ResidentInformation;
+
+namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
+{
+    [TestFixture]
+    public class GetAllCaseNotesUseCaseTest
+    {
+        private Mock<ISocialCareGateway> _mockSocialCareGateway;
+        private GetAllCaseNotesUseCase _classUnderTest;
+        private Fixture _fixture = new Fixture();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockSocialCareGateway = new Mock<ISocialCareGateway>();
+            _classUnderTest = new GetAllCaseNotesUseCase(_mockSocialCareGateway.Object);
+        }
+
+        [Test]
+        public void ReturnsListOfSummarisedCaseNoteInformation()
+        {
+            var stubbedCaseNotes = _fixture.CreateMany<CaseNoteInformation>();
+
+            _mockSocialCareGateway.Setup(x =>
+                    x.GetCaseNotes(34567))
+                .Returns(stubbedCaseNotes.ToList());
+
+            var response = _classUnderTest.Execute(34567);
+
+            response.Should().NotBeNull();
+            response.CaseNotes.Should().BeEquivalentTo(stubbedCaseNotes.ToResponse());
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllCaseNotesUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllCaseNotesUseCaseTests.cs
@@ -1,15 +1,13 @@
+using System.Collections.Generic;
 using System.Linq;
 using AutoFixture;
 using FluentAssertions;
 using Moq;
-using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
+using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.V1.Domain;
 using ResidentsSocialCarePlatformApi.V1.Factories;
 using ResidentsSocialCarePlatformApi.V1.Gateways;
 using ResidentsSocialCarePlatformApi.V1.UseCase;
-using NUnit.Framework;
-using ResidentsSocialCarePlatformApi.V1.Domain;
-using ResidentInformation = ResidentsSocialCarePlatformApi.V1.Domain.ResidentInformation;
-using ResidentInformationResponse = ResidentsSocialCarePlatformApi.V1.Boundary.Responses.ResidentInformation;
 
 namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
 {
@@ -25,6 +23,20 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         {
             _mockSocialCareGateway = new Mock<ISocialCareGateway>();
             _classUnderTest = new GetAllCaseNotesUseCase(_mockSocialCareGateway.Object);
+        }
+
+        [Test]
+        public void IfNoMatchingRecords_ReturnsAnEmptyResponse()
+        {
+            var noRecords = new List<CaseNoteInformation>();
+
+            _mockSocialCareGateway.Setup(x =>
+                    x.GetCaseNotes(34567))
+                .Returns(noRecords);
+
+            var response = _classUnderTest.Execute(34567);
+
+            response.CaseNotes.Should().BeEmpty();
         }
 
         [Test]

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
@@ -6,7 +6,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
     {
         public string MosaicId { get; set; }
 
-        public int CaseNoteId { get; set; }
+        public long CaseNoteId { get; set; }
 
         public int PersonVisitId { get; set; }
 

--- a/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
@@ -33,6 +33,19 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
             return people.Select(p => p.ToResponse()).ToList();
         }
 
+        public static List<Boundary.Responses.CaseNoteInformation> ToResponse(this IEnumerable<Domain.CaseNoteInformation> caseNotes)
+        {
+            return caseNotes.Select(caseNote => new Boundary.Responses.CaseNoteInformation
+            {
+                MosaicId = caseNote.MosaicId,
+                CaseNoteId = caseNote.CaseNoteId,
+                CaseNoteTitle = caseNote.CaseNoteTitle,
+                EffectiveDate = caseNote.EffectiveDate,
+                CreatedOn = caseNote.CreatedOn,
+                LastUpdatedOn = caseNote.LastUpdatedOn
+            }).ToList();
+        }
+
         private static List<Phone> ToResponse(this List<PhoneNumber> phoneNumbers)
         {
             return phoneNumbers.Select(number => new Phone

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210316113842_AddWorkersTable.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210316113842_AddWorkersTable.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/GetAllCaseNotesUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/GetAllCaseNotesUseCase.cs
@@ -1,0 +1,26 @@
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+using ResidentsSocialCarePlatformApi.V1.Factories;
+using ResidentsSocialCarePlatformApi.V1.Gateways;
+
+namespace ResidentsSocialCarePlatformApi.V1.UseCase
+{
+    public class GetAllCaseNotesUseCase
+    {
+        private ISocialCareGateway _socialCareGateway;
+
+        public GetAllCaseNotesUseCase(ISocialCareGateway socialCareGateway)
+        {
+            _socialCareGateway = socialCareGateway;
+        }
+
+        public CaseNoteInformationList Execute(long personId)
+        {
+            var caseNotes = _socialCareGateway.GetCaseNotes(personId);
+
+            return new CaseNoteInformationList
+            {
+                CaseNotes = caseNotes.ToResponse()
+            };
+        }
+    }
+}


### PR DESCRIPTION
### *What is the problem we're trying to solve*

Creating an endpoint to list historic case note data and make it available via the interim social care solution.
[JIRA TICKET](https://hackney.atlassian.net/browse/SCS-540)

### *What changes have we introduced*
This adds a use case that will call the gateway action for listing case notes.
It calls the gateway method with a specific person Id and converts the results obtained from the gateway into a list of response objects that will be passed to the controller.

#### _Checklist_

- [X] Added tests to cover all new production code
- [X] Checked all code for possible refactoring

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
- Focusing on getting the endpoint working end-to-end to test the connection with the [Service API](https://github.com/LBHackney-IT/social-care-case-viewer-api)
- Will work on making any changes to what the gateway returns after testing the connection with the [Service API](https://github.com/LBHackney-IT/social-care-case-viewer-api)