### PR TITLE
Add GetCaseNoteInformationById method for SocialCareGateway

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
@@ -113,7 +113,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
         {
             var noteType = TestHelper.CreateDatabaseNoteType();
             var worker = TestHelper.CreateDatabaseWorker();
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, workerSystemUserId: worker.SystemUserId, copiedBy: null);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, copiedBy: null);
             SocialCareContext.NoteTypes.Add(noteType);
             SocialCareContext.Workers.Add(worker);
             SocialCareContext.CaseNotes.Add(caseNote);
@@ -130,9 +130,11 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
         {
             var noteType = TestHelper.CreateDatabaseNoteType();
             var worker = TestHelper.CreateDatabaseWorker(systemUserId: "existingUser");
+            var updatedByWorker = TestHelper.CreateDatabaseWorker();
             var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, createdBy: "nonExistingUser");
             SocialCareContext.NoteTypes.Add(noteType);
             SocialCareContext.Workers.Add(worker);
+            SocialCareContext.Workers.Add(updatedByWorker);
             SocialCareContext.CaseNotes.Add(caseNote);
             SocialCareContext.SaveChanges();
 
@@ -141,11 +143,31 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
             response.CreatedByEmail.Should().BeNull();
             response.CreatedByName.Should().BeNull();
         }
+
+        [Test]
+        public void WhenUpdatedByWorkerIsNull_ReturnsNullForUpdatedByNameAndEmail()
+        {
+            var noteType = TestHelper.CreateDatabaseNoteType();
+            var worker = TestHelper.CreateDatabaseWorker(systemUserId: "existingUser");
+            var createdByWorker = TestHelper.CreateDatabaseWorker();
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, updatedBy: "nonExistingUser");
+            SocialCareContext.NoteTypes.Add(noteType);
+            SocialCareContext.Workers.Add(worker);
+            SocialCareContext.Workers.Add(createdByWorker);
+            SocialCareContext.CaseNotes.Add(caseNote);
+            SocialCareContext.SaveChanges();
+
+            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
+
+            response.LastUpdatedEmail.Should().BeNull();
+            response.LastUpdatedName.Should().BeNull();
+        }
+
         private CaseNote AddCaseNoteWithNoteTypeAndWorkerToDatabase(long id = 123, long personId = 123, string caseNoteType = "CASSUMASC", string caseNoteTypeDescription = "Case Summary (ASC)", string copiedBy = "CGYORFI", string workerFirstNames = "Csaba", string workerLastNames = "Gyorfi", string workerEmailAddress = "cgyorfi@email.com", string workerSystemUserId = "CGYORFI")
         {
             var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);
             var worker = TestHelper.CreateDatabaseWorker(workerFirstNames, workerLastNames, workerEmailAddress, workerSystemUserId);
-            var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type, copiedBy, worker.SystemUserId);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type, copiedBy, worker.SystemUserId, worker.SystemUserId);
 
             SocialCareContext.NoteTypes.Add(noteType);
             SocialCareContext.Workers.Add(worker);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
@@ -125,6 +125,22 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
             response.CopiedByEmail.Should().BeNull();
         }
 
+        [Test]
+        public void WhenCreatedByWorkerIsNull_ReturnsNullForCreatedByNameAndEmail()
+        {
+            var noteType = TestHelper.CreateDatabaseNoteType();
+            var worker = TestHelper.CreateDatabaseWorker(systemUserId: "existingUser");
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, createdBy: "nonExistingUser");
+            SocialCareContext.NoteTypes.Add(noteType);
+            SocialCareContext.Workers.Add(worker);
+            SocialCareContext.CaseNotes.Add(caseNote);
+            SocialCareContext.SaveChanges();
+
+            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
+
+            response.CreatedByEmail.Should().BeNull();
+            response.CreatedByName.Should().BeNull();
+        }
         private CaseNote AddCaseNoteWithNoteTypeAndWorkerToDatabase(long id = 123, long personId = 123, string caseNoteType = "CASSUMASC", string caseNoteTypeDescription = "Case Summary (ASC)", string copiedBy = "CGYORFI", string workerFirstNames = "Csaba", string workerLastNames = "Gyorfi", string workerEmailAddress = "cgyorfi@email.com", string workerSystemUserId = "CGYORFI")
         {
             var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
@@ -1,0 +1,142 @@
+using FluentAssertions;
+using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.V1.Gateways;
+using ResidentsSocialCarePlatformApi.Tests.V1.Helper;
+using ResidentsSocialCarePlatformApi.V1.Infrastructure;
+
+namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
+{
+    [NonParallelizable]
+    [TestFixture]
+    public class GetCaseNoteInformationByIdTests : DatabaseTests
+    {
+        private SocialCareGateway _classUnderTest;
+
+        [SetUp]
+        public void Setup()
+        {
+            _classUnderTest = new SocialCareGateway(SocialCareContext);
+        }
+
+        [Test]
+        public void WhenThereIsNoMatchingRecord_ReturnsNull()
+        {
+            const int existentCaseNoteId = 123;
+            const int nonexistentCaseNoteId = 456;
+            AddCaseNoteWithNoteTypeAndWorkerToDatabase(id: existentCaseNoteId);
+
+            var response = _classUnderTest.GetCaseNoteInformationById(nonexistentCaseNoteId);
+
+            response.Should().BeNull();
+        }
+
+        [Test]
+        public void WhenThereAreMultipleCaseNotes_ReturnsCaseNoteWithMatchingId()
+        {
+            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase(id: 123);
+            AddCaseNoteWithNoteTypeAndWorkerToDatabase(id: 456, caseNoteType: "DIFF", caseNoteTypeDescription: "Different");
+
+            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
+
+            response.CaseNoteId.Should().Be(caseNote.Id);
+        }
+
+        [Test]
+        public void WhenThereIsAMatchingRecord_ReturnsDetailsFromCaseNotes()
+        {
+            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase();
+
+            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
+
+            response.MosaicId.Should().Be(caseNote.PersonId.ToString());
+            response.CaseNoteId.Should().Be(caseNote.Id);
+            response.PersonVisitId.Should().Be(caseNote.PersonVisitId);
+            response.CaseNoteTitle.Should().Be(caseNote.Title);
+            response.EffectiveDate.Should().Be(caseNote.EffectiveDate);
+            response.CreatedOn.Should().Be(caseNote.CreatedOn);
+            response.LastUpdatedOn.Should().Be(caseNote.LastUpdatedOn);
+            response.CaseNoteContent.Should().Be(caseNote.Note);
+            response.RootCaseNoteId.Should().Be(caseNote.RootCaseNoteId);
+            response.CompletedDate.Should().Be(caseNote.CompletedDate);
+            response.TimeoutDate.Should().Be(caseNote.TimeoutDate);
+            response.CopyOfCaseNoteId.Should().Be(caseNote.CopyOfCaseNoteId);
+            response.CopiedDate.Should().Be(caseNote.CopiedDate);
+        }
+
+        [Test]
+        public void WhenThereIsAMatchingRecord_ReturnsNoteTypeFromNoteTypes()
+        {
+            const string noteType = "NOTETYPE";
+            const string noteTypeDescription = "Note Type Description";
+            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase(caseNoteType: noteType, caseNoteTypeDescription: noteTypeDescription);
+
+            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
+
+            response.NoteType.Should().Be(noteTypeDescription);
+        }
+
+        [Test]
+        public void WhenThereIsAMatchingRecord_ReturnsDetailsFromWorkers()
+        {
+            const string workerEmailAddress = "adora@grayskull.com";
+            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase(copiedBy: "AGRAYSKULL", workerFirstNames: "Adora", workerLastNames: "Grayskull", workerEmailAddress: workerEmailAddress, workerSystemUserId: "AGRAYSKULL");
+
+            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
+
+            response.CreatedByName.Should().Be("Adora Grayskull");
+            response.CreatedByEmail.Should().Be(workerEmailAddress);
+            response.LastUpdatedName.Should().Be("Adora Grayskull");
+            response.LastUpdatedEmail.Should().Be(workerEmailAddress);
+            response.CopiedByName.Should().Be("Adora Grayskull");
+            response.CopiedByEmail.Should().Be(workerEmailAddress);
+        }
+
+        [Test]
+        public void WhenNoteTypeCannotBeFound_ReturnsNullForNoteType()
+        {
+            const string nonexistentNoteType = "NONEXISTENT";
+            var existentNoteType = TestHelper.CreateDatabaseNoteType("EXISTENT", "Existent Case Note Type");
+            var worker = TestHelper.CreateDatabaseWorker();
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: nonexistentNoteType);
+            SocialCareContext.NoteTypes.Add(existentNoteType);
+            SocialCareContext.Workers.Add(worker);
+            SocialCareContext.CaseNotes.Add(caseNote);
+            SocialCareContext.SaveChanges();
+
+            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
+
+            response.NoteType.Should().BeNull();
+        }
+
+        [Test]
+        public void WhenCopiedByIsNull_ReturnsNullForCopiedByNameAndCopiedByEmail()
+        {
+            var noteType = TestHelper.CreateDatabaseNoteType();
+            var worker = TestHelper.CreateDatabaseWorker();
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, workerSystemUserId: worker.SystemUserId, copiedBy: null);
+            SocialCareContext.NoteTypes.Add(noteType);
+            SocialCareContext.Workers.Add(worker);
+            SocialCareContext.CaseNotes.Add(caseNote);
+            SocialCareContext.SaveChanges();
+
+            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
+
+            response.CopiedByName.Should().BeNull();
+            response.CopiedByEmail.Should().BeNull();
+        }
+
+        private CaseNote AddCaseNoteWithNoteTypeAndWorkerToDatabase(long id = 123, long personId = 123, string caseNoteType = "CASSUMASC", string caseNoteTypeDescription = "Case Summary (ASC)", string copiedBy = "CGYORFI", string workerFirstNames = "Csaba", string workerLastNames = "Gyorfi", string workerEmailAddress = "cgyorfi@email.com", string workerSystemUserId = "CGYORFI")
+        {
+            var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);
+            var worker = TestHelper.CreateDatabaseWorker(workerFirstNames, workerLastNames, workerEmailAddress, workerSystemUserId);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type, copiedBy, worker.SystemUserId);
+
+            SocialCareContext.NoteTypes.Add(noteType);
+            SocialCareContext.Workers.Add(worker);
+            SocialCareContext.CaseNotes.Add(caseNote);
+            SocialCareContext.SaveChanges();
+
+            return caseNote;
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
@@ -30,7 +30,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         public void WhenThereIsOneMatch_ReturnsCaseNoteInformationForAGivenPersonId()
         {
             var person = AddPersonToDatabase();
-            AddCaseNoteToDatabase(person.Id);
+            AddCaseNoteToDatabase(personId: person.Id);
 
             var response = _classUnderTest.GetCaseNotes(person.Id);
 
@@ -41,8 +41,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         public void WhenThereAreMatchingRecords_ReturnsCaseNoteInformationForAGivenPersonId()
         {
             var person = AddPersonToDatabase();
-            AddCaseNoteToDatabase(person.Id);
-            AddCaseNoteToDatabase(person.Id);
+            AddCaseNoteToDatabase(id: 123, personId: person.Id);
+            AddCaseNoteToDatabase(id: 456, personId: person.Id);
 
             var response = _classUnderTest.GetCaseNotes(person.Id);
 
@@ -55,7 +55,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         public void WhenThereAreMatchingRecords_InformationReturnedIsASummaryOfTheCaseNotesForASpecificPersonId()
         {
             var person = AddPersonToDatabase();
-            var caseNote = AddCaseNoteToDatabase(person.Id);
+            var caseNote = AddCaseNoteToDatabase(personId: person.Id);
 
             var expectedCaseNoteInformation = new CaseNoteInformation
             {
@@ -80,9 +80,9 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             return databaseEntity;
         }
 
-        private CaseNote AddCaseNoteToDatabase(long id)
+        private CaseNote AddCaseNoteToDatabase(long personId, long id = 123)
         {
-            var caseNote = TestHelper.CreateDatabaseCaseNote(id);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(id: id, personId: personId);
             SocialCareContext.CaseNotes.Add(caseNote);
             SocialCareContext.SaveChanges();
             return caseNote;

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -58,7 +58,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
         }
 
         public static CaseNote CreateDatabaseCaseNote(long id = 123, long personId = 123, string noteType = "CASSUMASC",
-            string copiedBy = "CGYORFI", string workerSystemUserId = "CGYORFI", string createdBy="CGYORFI")
+            string copiedBy = "CGYORFI", string createdBy="CGYORFI", string updatedBy = "CGYORFI")
         {
             var faker = new Fixture();
 
@@ -67,7 +67,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .With(caseNote => caseNote.PersonId, personId)
                 .With(caseNote => caseNote.NoteType, noteType)
                 .With(caseNote => caseNote.CreatedBy, createdBy)
-                .With(caseNote => caseNote.LastUpdatedBy, workerSystemUserId)
+                .With(caseNote => caseNote.LastUpdatedBy, updatedBy)
                 .With(caseNote => caseNote.CopiedBy, copiedBy)
                 .Create();
         }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -57,7 +57,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .Create();
         }
 
-        public static CaseNote CreateDatabaseCaseNote(long id = 123, long personId = 123, string noteType = "CASSUMASC", string copiedBy = "CGYORFI", string workerSystemUserId = "CGYORFI")
+        public static CaseNote CreateDatabaseCaseNote(long id = 123, long personId = 123, string noteType = "CASSUMASC",
+            string copiedBy = "CGYORFI", string workerSystemUserId = "CGYORFI", string createdBy="CGYORFI")
         {
             var faker = new Fixture();
 
@@ -65,7 +66,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .With(caseNote => caseNote.Id, id)
                 .With(caseNote => caseNote.PersonId, personId)
                 .With(caseNote => caseNote.NoteType, noteType)
-                .With(caseNote => caseNote.CreatedBy, workerSystemUserId)
+                .With(caseNote => caseNote.CreatedBy, createdBy)
                 .With(caseNote => caseNote.LastUpdatedBy, workerSystemUserId)
                 .With(caseNote => caseNote.CopiedBy, copiedBy)
                 .Create();

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -57,12 +57,39 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .Create();
         }
 
-        public static CaseNote CreateDatabaseCaseNote(long personId)
+        public static CaseNote CreateDatabaseCaseNote(long id = 123, long personId = 123, string noteType = "CASSUMASC", string copiedBy = "CGYORFI", string workerSystemUserId = "CGYORFI")
         {
             var faker = new Fixture();
 
             return faker.Build<CaseNote>()
+                .With(caseNote => caseNote.Id, id)
                 .With(caseNote => caseNote.PersonId, personId)
+                .With(caseNote => caseNote.NoteType, noteType)
+                .With(caseNote => caseNote.CreatedBy, workerSystemUserId)
+                .With(caseNote => caseNote.LastUpdatedBy, workerSystemUserId)
+                .With(caseNote => caseNote.CopiedBy, copiedBy)
+                .Create();
+        }
+
+        public static NoteType CreateDatabaseNoteType(string noteType = "CASSUMASC", string description = "Case Summary (ASC)")
+        {
+            var faker = new Fixture();
+
+            return faker.Build<NoteType>()
+                .With(noteType => noteType.Type, noteType)
+                .With(noteType => noteType.Description, description)
+                .Create();
+        }
+
+        public static Worker CreateDatabaseWorker(string firstNames = "Csaba", string lastNames = "Gyorfi", string emailAddress = "cgyorfi@email.com", string systemUserId = "CGYORFI")
+        {
+            var faker = new Fixture();
+
+            return faker.Build<Worker>()
+                .With(worker => worker.FirstNames, firstNames)
+                .With(worker => worker.LastNames, lastNames)
+                .With(worker => worker.EmailAddress, emailAddress)
+                .With(worker => worker.SystemUserId, systemUserId)
                 .Create();
         }
     }

--- a/ResidentsSocialCarePlatformApi/V1/Domain/CaseNoteInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Domain/CaseNoteInformation.cs
@@ -8,7 +8,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Domain
 
         public long CaseNoteId { get; set; }
 
-        public int PersonVisitId { get; set; }
+        public long PersonVisitId { get; set; }
 
         public string NoteType { get; set; }
 
@@ -30,13 +30,13 @@ namespace ResidentsSocialCarePlatformApi.V1.Domain
 
         public string CaseNoteContent { get; set; }
 
-        public int RootCaseNoteId { get; set; }
+        public long RootCaseNoteId { get; set; }
 
         public DateTime CompletedDate { get; set; }
 
         public DateTime TimeoutDate { get; set; }
 
-        public int CopyOfCaseNoteId { get; set; }
+        public long CopyOfCaseNoteId { get; set; }
 
         public string CopiedBy { get; set; }
 

--- a/ResidentsSocialCarePlatformApi/V1/Domain/CaseNoteInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Domain/CaseNoteInformation.cs
@@ -38,7 +38,9 @@ namespace ResidentsSocialCarePlatformApi.V1.Domain
 
         public long CopyOfCaseNoteId { get; set; }
 
-        public string CopiedBy { get; set; }
+        public string CopiedByName { get; set; }
+
+        public string CopiedByEmail { get; set; }
 
         public DateTime CopiedDate { get; set; }
     }

--- a/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
@@ -71,10 +71,17 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
             {
                 MosaicId = caseNote.PersonId.ToString(),
                 CaseNoteId = caseNote.Id,
-                NoteType = caseNote.NoteType,
                 CaseNoteTitle = caseNote.Title,
                 CreatedOn = caseNote.CreatedOn,
-                CreatedByName = caseNote.CreatedBy
+                PersonVisitId = caseNote.PersonVisitId,
+                CaseNoteContent = caseNote.Note,
+                RootCaseNoteId = caseNote.RootCaseNoteId,
+                EffectiveDate = caseNote.EffectiveDate,
+                LastUpdatedOn = caseNote.LastUpdatedOn,
+                CompletedDate = caseNote.CompletedDate,
+                TimeoutDate = caseNote.TimeoutDate,
+                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
+                CopiedDate = caseNote.CopiedDate
             };
         }
     }

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/ISocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/ISocialCareGateway.cs
@@ -12,5 +12,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
         Domain.ResidentInformation InsertResident(string firstName, string lastName);
 
         List<Domain.CaseNoteInformation> GetCaseNotes(long personId);
+
+        Domain.CaseNoteInformation GetCaseNoteInformationById(long caseNoteId);
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -109,10 +109,13 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
                 caseNoteInformation.CreatedByEmail = createdByWorker.EmailAddress;
             }
 
-            // what if lastUpdatedWorker is null (test this)
             var lastUpdatedByWorker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId == caseNote.LastUpdatedBy);
-            caseNoteInformation.LastUpdatedName = $"{lastUpdatedByWorker.FirstNames} {lastUpdatedByWorker.LastNames}";
-            caseNoteInformation.LastUpdatedEmail = lastUpdatedByWorker.EmailAddress;
+            if (lastUpdatedByWorker != null)
+            {
+                caseNoteInformation.LastUpdatedName =
+                    $"{lastUpdatedByWorker.FirstNames} {lastUpdatedByWorker.LastNames}";
+                caseNoteInformation.LastUpdatedEmail = lastUpdatedByWorker.EmailAddress;
+            }
 
             if (caseNote.CopiedBy != null)
             {

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -103,9 +103,13 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
             caseNoteInformation.NoteType = noteType?.Description;
 
             var createdByWorker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId == caseNote.CreatedBy);
-            caseNoteInformation.CreatedByName = $"{createdByWorker.FirstNames} {createdByWorker.LastNames}";
-            caseNoteInformation.CreatedByEmail = createdByWorker.EmailAddress;
+            if (createdByWorker != null)
+            {
+                caseNoteInformation.CreatedByName = $"{createdByWorker.FirstNames} {createdByWorker.LastNames}";
+                caseNoteInformation.CreatedByEmail = createdByWorker.EmailAddress;
+            }
 
+            // what if lastUpdatedWorker is null (test this)
             var lastUpdatedByWorker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId == caseNote.LastUpdatedBy);
             caseNoteInformation.LastUpdatedName = $"{lastUpdatedByWorker.FirstNames} {lastUpdatedByWorker.LastNames}";
             caseNoteInformation.LastUpdatedEmail = lastUpdatedByWorker.EmailAddress;

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -1,9 +1,9 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using ResidentsSocialCarePlatformApi.V1.Factories;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
-using DomainAddress = ResidentsSocialCarePlatformApi.V1.Domain.Address;
 
 namespace ResidentsSocialCarePlatformApi.V1.Gateways
 {
@@ -89,6 +89,35 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
             return _socialCareContext.CaseNotes
                 .Where(note => note.PersonId == personId).ToDomain()
                 .ToList();
+        }
+
+        public Domain.CaseNoteInformation GetCaseNoteInformationById(long caseNoteId)
+        {
+            var caseNote = _socialCareContext.CaseNotes.FirstOrDefault(caseNote => caseNote.Id == caseNoteId);
+
+            if (caseNote == null) return null;
+
+            var caseNoteInformation = caseNote.ToDomain();
+
+            var noteType = _socialCareContext.NoteTypes.FirstOrDefault(noteType => noteType.Type == caseNote.NoteType);
+            caseNoteInformation.NoteType = noteType?.Description;
+
+            var createdByWorker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId == caseNote.CreatedBy);
+            caseNoteInformation.CreatedByName = $"{createdByWorker.FirstNames} {createdByWorker.LastNames}";
+            caseNoteInformation.CreatedByEmail = createdByWorker.EmailAddress;
+
+            var lastUpdatedByWorker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId == caseNote.LastUpdatedBy);
+            caseNoteInformation.LastUpdatedName = $"{lastUpdatedByWorker.FirstNames} {lastUpdatedByWorker.LastNames}";
+            caseNoteInformation.LastUpdatedEmail = lastUpdatedByWorker.EmailAddress;
+
+            if (caseNote.CopiedBy != null)
+            {
+                var copiedByWorker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId == caseNote.CopiedBy);
+                caseNoteInformation.CopiedByName = $"{copiedByWorker.FirstNames} {copiedByWorker.LastNames}";
+                caseNoteInformation.CopiedByEmail = copiedByWorker.EmailAddress;
+            }
+
+            return caseNoteInformation;
         }
 
         private List<long> PeopleIds(int cursor, int limit, long? id, string firstname, string lastname, string dateOfBirth, string contextflag)
@@ -189,5 +218,4 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
             return $"%{str?.Replace(" ", "")}%";
         }
     }
-
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/NoteType.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/NoteType.cs
@@ -8,6 +8,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
     {
         [Column("note_type")]
         [MaxLength(16)]
+        [Key]
         public string Type { get; set; }
 
         [Column("note_type_description")]

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/SocialCareContext.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/SocialCareContext.cs
@@ -25,9 +25,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
                     telephoneNumber.Id,
                     telephoneNumber.PersonId
                 });
-
-            // set Note Type table to have no defined primary key
-            modelBuilder.Entity<NoteType>().HasNoKey();
         }
     }
 }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

In the Interim Social Care System, we want to be able to display the details of a historic case note for a resident.

### *What changes have we introduced*

This PR adds a new method to the `SocialCareGateway` to enable retrieving of case note information from 3 different tables: `CaseNotes`, `NoteTypes` and `Workers`.

FYI, I added `CopiedByEmail` for `Domain.CaseNoteInformation` just to match `CreatedBy` and `UpdatedBy`.

### *Guidance to review*

- Best to review commit by commit.
- Changes to `ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs` were made as updates to the test helpers were made.
- Was reluctant to extract methods for the `SocialCareGateway#GetCaseNoteInformationById` as I didn't think it would improve readability much, let me know what you think!

### *Follow up actions after merging PR*

- [ ] Add new use case
- [ ] Add new controller action

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-523