### PR TITLE
Add GetCaseNoteInformationById use case

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -159,5 +159,62 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
 
             domain.ToResponse().Should().BeEquivalentTo(expectedResponse);
         }
+
+        [Test]
+        public void CanMapCaseNoteInformationFromDomainToResponse()
+        {
+            var dateTime = new DateTime(2021, 3, 1, 15, 30, 00);
+            const string formattedDateTime = "2021-03-01T15:30:00";
+
+            var domain = new CaseNoteInformation
+            {
+                MosaicId = "12345",
+                CaseNoteId = 67890,
+                CaseNoteTitle = "I AM A CASE NOTE",
+                EffectiveDate = dateTime,
+                CreatedOn = dateTime,
+                LastUpdatedOn = dateTime,
+                PersonVisitId = 456,
+                NoteType = "Case Summary (ASC)",
+                CreatedByName = "Catra Grayskull",
+                CreatedByEmail = "catra@grayskull.com",
+                LastUpdatedName = "Catra Grayskull",
+                LastUpdatedEmail = "catra@grayskull.com",
+                CaseNoteContent = "I am case note content.",
+                RootCaseNoteId = 789,
+                CompletedDate = dateTime,
+                TimeoutDate = dateTime,
+                CopyOfCaseNoteId = 567,
+                CopiedDate = dateTime,
+                CopiedByName = "Catra Grayskull",
+                CopiedByEmail = "catra@grayskull.com",
+            };
+
+            var expectedResponse = new CaseNoteInformationResponse
+            {
+                MosaicId = "12345",
+                CaseNoteId = 67890,
+                CaseNoteTitle = "I AM A CASE NOTE",
+                EffectiveDate = formattedDateTime,
+                CreatedOn = formattedDateTime,
+                LastUpdatedOn = formattedDateTime,
+                PersonVisitId = 456,
+                NoteType = "Case Summary (ASC)",
+                CreatedByName = "Catra Grayskull",
+                CreatedByEmail = "catra@grayskull.com",
+                LastUpdatedName = "Catra Grayskull",
+                LastUpdatedEmail = "catra@grayskull.com",
+                CaseNoteContent = "I am case note content.",
+                RootCaseNoteId = 789,
+                CompletedDate = formattedDateTime,
+                TimeoutDate = formattedDateTime,
+                CopyOfCaseNoteId = 567,
+                CopiedDate = formattedDateTime,
+                CopiedByName = "Catra Grayskull",
+                CopiedByEmail = "catra@grayskull.com",
+            };
+
+            domain.ToResponse().Should().BeEquivalentTo(expectedResponse);
+        }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetCaseNoteInformationByIdUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetCaseNoteInformationByIdUseCaseTests.cs
@@ -1,0 +1,51 @@
+using System.Collections.Generic;
+using System.Linq;
+using AutoFixture;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.V1.Domain;
+using ResidentsSocialCarePlatformApi.V1.Factories;
+using ResidentsSocialCarePlatformApi.V1.Gateways;
+using ResidentsSocialCarePlatformApi.V1.UseCase;
+
+namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
+{
+    [TestFixture]
+    public class GetCaseNoteInformationByIdUseCaseTest
+    {
+        private Mock<ISocialCareGateway> _mockSocialCareGateway;
+        private GetCaseNoteInformationByIdUseCase _classUnderTest;
+        private Fixture _fixture = new Fixture();
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockSocialCareGateway = new Mock<ISocialCareGateway>();
+            _classUnderTest = new GetCaseNoteInformationByIdUseCase(_mockSocialCareGateway.Object);
+        }
+
+        [Test]
+        public void WhenThereIsNoMatchingCaseNote_ReturnsNull()
+        {
+            CaseNoteInformation noMatchingCaseNote = null;
+            _mockSocialCareGateway.Setup(x => x.GetCaseNoteInformationById(123)).Returns(noMatchingCaseNote);
+
+            var response = _classUnderTest.Execute(123);
+
+            response.Should().BeNull();
+        }
+
+        [Test]
+        public void WhenThereIsAMatchingCaseNote_ReturnsCaseNoteInformation()
+        {
+            var caseNote = _fixture.Create<CaseNoteInformation>();
+            _mockSocialCareGateway.Setup(x => x.GetCaseNoteInformationById(123)).Returns(caseNote);
+
+            var response = _classUnderTest.Execute(123);
+
+            response.Should().NotBeNull();
+            response.Should().BeEquivalentTo(caseNote.ToResponse());
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
@@ -8,7 +8,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 
         public long CaseNoteId { get; set; }
 
-        public int PersonVisitId { get; set; }
+        public long PersonVisitId { get; set; }
 
         public string NoteType { get; set; }
 
@@ -30,15 +30,17 @@ namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 
         public string CaseNoteContent { get; set; }
 
-        public int RootCaseNoteId { get; set; }
+        public long RootCaseNoteId { get; set; }
 
         public string CompletedDate { get; set; }
 
         public string TimeoutDate { get; set; }
 
-        public int CopyOfCaseNoteId { get; set; }
+        public long CopyOfCaseNoteId { get; set; }
 
-        public string CopiedBy { get; set; }
+        public string CopiedByName { get; set; }
+
+        public string CopiedByEmail { get; set; }
 
         public string CopiedDate { get; set; }
     }

--- a/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
@@ -25,9 +25,37 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 Restricted = domain.Restricted
             };
         }
+
         public static List<Boundary.Responses.ResidentInformation> ToResponse(this IEnumerable<Domain.ResidentInformation> people)
         {
             return people.Select(p => p.ToResponse()).ToList();
+        }
+
+        public static Boundary.Responses.CaseNoteInformation ToResponse(this Domain.CaseNoteInformation caseNote)
+        {
+            return new Boundary.Responses.CaseNoteInformation
+            {
+                MosaicId = caseNote.MosaicId,
+                CaseNoteId = caseNote.CaseNoteId,
+                CaseNoteTitle = caseNote.CaseNoteTitle,
+                EffectiveDate = caseNote.EffectiveDate.ToString("s"),
+                CreatedOn = caseNote.CreatedOn.ToString("s"),
+                LastUpdatedOn = caseNote.LastUpdatedOn.ToString("s"),
+                PersonVisitId = caseNote.PersonVisitId,
+                NoteType = caseNote.NoteType,
+                CreatedByName = caseNote.CreatedByName,
+                CreatedByEmail = caseNote.CreatedByEmail,
+                LastUpdatedName = caseNote.LastUpdatedName,
+                LastUpdatedEmail = caseNote.LastUpdatedEmail,
+                CaseNoteContent = caseNote.CaseNoteContent,
+                RootCaseNoteId = caseNote.RootCaseNoteId,
+                CompletedDate = caseNote.CompletedDate.ToString("s"),
+                TimeoutDate = caseNote.TimeoutDate.ToString("s"),
+                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
+                CopiedDate = caseNote.CopiedDate.ToString("s"),
+                CopiedByName = caseNote.CopiedByName,
+                CopiedByEmail = caseNote.CopiedByEmail,
+            };
         }
 
         public static List<Boundary.Responses.CaseNoteInformation> ToResponse(this IEnumerable<Domain.CaseNoteInformation> caseNotes)

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/GetCaseNoteInformationByIdUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/GetCaseNoteInformationByIdUseCase.cs
@@ -1,0 +1,26 @@
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+using ResidentsSocialCarePlatformApi.V1.Factories;
+using ResidentsSocialCarePlatformApi.V1.Gateways;
+using ResidentsSocialCarePlatformApi.V1.Infrastructure;
+using ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces;
+
+namespace ResidentsSocialCarePlatformApi.V1.UseCase
+{
+    public class GetCaseNoteInformationByIdUseCase : IGetCaseNoteInformationByIdUseCase
+    {
+        private ISocialCareGateway _socialCareGateway;
+
+        public GetCaseNoteInformationByIdUseCase(ISocialCareGateway socialCareGateway)
+        {
+            _socialCareGateway = socialCareGateway;
+        }
+
+        public CaseNoteInformation Execute(long id)
+        {
+            var caseNote = _socialCareGateway.GetCaseNoteInformationById(id);
+
+            return caseNote?.ToResponse();
+        }
+    }
+
+}

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/Interfaces/IGetCaseNoteInformationByIdUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/Interfaces/IGetCaseNoteInformationByIdUseCase.cs
@@ -1,0 +1,9 @@
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+
+namespace ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces
+{
+    public interface IGetCaseNoteInformationByIdUseCase
+    {
+        CaseNoteInformation Execute(long id);
+    }
+}


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

In the Interim Social Care System, we want to be able to display the details of a historic case note for a resident.

### *What changes have we introduced*

This PR adds a new use case to get a case note by an `id` by calling the `SocialCareGatway#GetCaseNoteInformatioById` method added in #8.

### *Follow up actions after merging PR*

- [x] Add new use case
- [ ] Add new controller action with end to end test

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-523