### PR TITLE
Add controller action for getting a case note

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/CaseNotesControllerTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/CaseNotesControllerTests.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+using ResidentsSocialCarePlatformApi.V1.Controllers;
+using ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces;
+using NUnit.Framework;
+using ResidentInformation = ResidentsSocialCarePlatformApi.V1.Boundary.Responses.ResidentInformation;
+
+namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
+{
+    [TestFixture]
+    public class CaseNotesControllerTests
+    {
+        private CaseNotesController _classUnderTest;
+        private Mock<IGetCaseNoteInformationByIdUseCase> _mockGetCaseNoteInformationByIdUseCase;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockGetCaseNoteInformationByIdUseCase = new Mock<IGetCaseNoteInformationByIdUseCase>();
+
+            _classUnderTest = new CaseNotesController(_mockGetCaseNoteInformationByIdUseCase.Object);
+        }
+
+        [Test]
+        public void GetCaseNote_WhenThereIsAMatchingCaseNoteId_ReturnsCaseNoteInformation()
+        {
+            const string formattedDateTime = "2021-03-01T15:30:00";
+            var caseNoteInformation = new CaseNoteInformation
+            {
+                MosaicId = "12345",
+                CaseNoteId = 67890,
+                CaseNoteTitle = "I AM A CASE NOTE",
+                EffectiveDate = formattedDateTime,
+                CreatedOn = formattedDateTime,
+                LastUpdatedOn = formattedDateTime,
+                PersonVisitId = 456,
+                NoteType = "Case Summary (ASC)",
+                CreatedByName = "Finn Grayskull",
+                CreatedByEmail = "finn@grayskull.com",
+                LastUpdatedName = "Finn Grayskull",
+                LastUpdatedEmail = "finn@grayskull.com",
+                CaseNoteContent = "I am case note content.",
+                RootCaseNoteId = 789,
+                CompletedDate = formattedDateTime,
+                TimeoutDate = formattedDateTime,
+                CopyOfCaseNoteId = 567,
+                CopiedDate = formattedDateTime,
+                CopiedByName = "Finn Grayskull",
+                CopiedByEmail = "finn@grayskull.com",
+            };
+            _mockGetCaseNoteInformationByIdUseCase.Setup(x => x.Execute(67890)).Returns(caseNoteInformation);
+
+            var response = _classUnderTest.GetCaseNote(67890) as OkObjectResult;
+
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(caseNoteInformation);
+        }
+
+        [Test]
+        public void GetCaseNote_WhenThereIsNoAMatchingCaseNoteId_ReturnsNotFound()
+        {
+            CaseNoteInformation caseNoteNotFound = null;
+            _mockGetCaseNoteInformationByIdUseCase.Setup(x => x.Execute(67890)).Returns(caseNoteNotFound);
+
+            var response = _classUnderTest.GetCaseNote(67890) as NotFoundResult;
+
+            response.StatusCode.Should().Be(404);
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
@@ -13,9 +13,9 @@ using ResidentInformation = ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
 {
     [TestFixture]
-    public class SocialCareControllerTests
+    public class ResidentsControllerTests
     {
-        private SocialCareController _classUnderTest;
+        private ResidentsController _classUnderTest;
         private Mock<IGetAllResidentsUseCase> _mockGetAllResidentsUseCase;
         private Mock<IGetEntityByIdUseCase> _mockGetEntityByIdUseCase;
 
@@ -29,7 +29,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
 
             _mockGetAllCaseNotesUseCase = new Mock<IGetAllCaseNotesUseCase>();
 
-            _classUnderTest = new SocialCareController(_mockGetAllResidentsUseCase.Object,
+            _classUnderTest = new ResidentsController(_mockGetAllResidentsUseCase.Object,
                 _mockGetEntityByIdUseCase.Object, _mockGetAllCaseNotesUseCase.Object);
         }
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -75,5 +75,41 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
                 LastUpdatedOn = caseNote.LastUpdatedOn.ToString("s")
             };
         }
+
+        public static CaseNoteInformation AddCaseNoteWithNoteTypeAndWorkerToDatabase(SocialCareContext socialCareContext)
+        {
+            var noteType = TestHelper.CreateDatabaseNoteType();
+            var worker = TestHelper.CreateDatabaseWorker(firstNames: "Bow", lastNames: "Archer");
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, createdBy: worker.SystemUserId, updatedBy: worker.SystemUserId, copiedBy: worker.SystemUserId);
+
+            socialCareContext.NoteTypes.Add(noteType);
+            socialCareContext.Workers.Add(worker);
+            socialCareContext.CaseNotes.Add(caseNote);
+            socialCareContext.SaveChanges();
+
+            return new CaseNoteInformation
+            {
+                MosaicId = caseNote.PersonId.ToString(),
+                CaseNoteId = caseNote.Id,
+                CaseNoteTitle = caseNote.Title,
+                EffectiveDate = caseNote.EffectiveDate.ToString("s"),
+                CreatedOn = caseNote.CreatedOn.ToString("s"),
+                LastUpdatedOn = caseNote.LastUpdatedOn.ToString("s"),
+                PersonVisitId = caseNote.PersonVisitId,
+                NoteType = noteType.Description,
+                CreatedByName = "Bow Archer",
+                CreatedByEmail = worker.EmailAddress,
+                LastUpdatedName = "Bow Archer",
+                LastUpdatedEmail = worker.EmailAddress,
+                CaseNoteContent = caseNote.Note,
+                RootCaseNoteId = caseNote.RootCaseNoteId,
+                CompletedDate = caseNote.CompletedDate.ToString("s"),
+                TimeoutDate = caseNote.TimeoutDate.ToString("s"),
+                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
+                CopiedDate = caseNote.CopiedDate.ToString("s"),
+                CopiedByName = "Bow Archer",
+                CopiedByEmail = worker.EmailAddress,
+            };
+        }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetCaseNote.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetCaseNote.cs
@@ -11,7 +11,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
     public class GetCaseNote : EndToEndTests<Startup>
     {
         [Test]
-        public async Task ReturnsCaseNoteForProvidedCaseNoteId()
+        public async Task WhenThereIsAMatchingCaseNoteId_Returns200AndCaseNoteInformation()
         {
             var caseNote = E2ETestHelpers.AddCaseNoteWithNoteTypeAndWorkerToDatabase(SocialCareContext);
             var uri = new Uri($"api/v1/case-notes/{caseNote.CaseNoteId}", UriKind.Relative);
@@ -25,6 +25,17 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
             var convertedResponse = JsonConvert.DeserializeObject<CaseNoteInformation>(stringContent);
 
             convertedResponse.Should().BeEquivalentTo(caseNote);
+        }
+
+        [Test]
+        public async Task WhenThereIsNotAMatchingCaseNoteId_Returns404()
+        {
+            var nonExistentCaseNoteId = "1234";
+            var uri = new Uri($"api/v1/case-notes/{nonExistentCaseNoteId}", UriKind.Relative);
+
+            var response = Client.GetAsync(uri);
+
+            response.Result.StatusCode.Should().Be(404);
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetCaseNote.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetCaseNote.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+
+namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
+{
+    [TestFixture]
+    public class GetCaseNote : EndToEndTests<Startup>
+    {
+        [Test]
+        public async Task ReturnsCaseNoteForProvidedCaseNoteId()
+        {
+            var caseNote = E2ETestHelpers.AddCaseNoteWithNoteTypeAndWorkerToDatabase(SocialCareContext);
+            var uri = new Uri($"api/v1/case-notes/{caseNote.CaseNoteId}", UriKind.Relative);
+
+            var response = Client.GetAsync(uri);
+
+            response.Result.StatusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<CaseNoteInformation>(stringContent);
+
+            convertedResponse.Should().BeEquivalentTo(caseNote);
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/Startup.cs
+++ b/ResidentsSocialCarePlatformApi/Startup.cs
@@ -133,6 +133,7 @@ namespace ResidentsSocialCarePlatformApi
             services.AddScoped<IGetAllResidentsUseCase, GetAllResidentsUseCase>();
             services.AddScoped<IGetEntityByIdUseCase, GetEntityByIdUseCase>();
             services.AddScoped<IGetAllCaseNotesUseCase, GetAllCaseNotesUseCase>();
+            services.AddScoped<IGetCaseNoteInformationByIdUseCase, GetCaseNoteInformationByIdUseCase>();
             services.AddScoped<IValidatePostcode, ValidatePostcode>();
         }
 

--- a/ResidentsSocialCarePlatformApi/V1/Controllers/CaseNotesController.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Controllers/CaseNotesController.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces;
+
+namespace ResidentsSocialCarePlatformApi.V1.Controllers
+{
+    [ApiController]
+    [Route("api/v1/case-notes")]
+    [Produces("application/json")]
+    [ApiVersion("1.0")]
+    public class CaseNotesController : BaseController
+    {
+        private IGetCaseNoteInformationByIdUseCase _getCaseNoteInformationByIdUseCase;
+
+        public CaseNotesController(IGetCaseNoteInformationByIdUseCase getCaseNoteInformationByIdUseCase)
+        {
+            _getCaseNoteInformationByIdUseCase = getCaseNoteInformationByIdUseCase;
+        }
+
+        /// /// <summary>
+        /// Get a case note by ID
+        /// </summary>
+        /// <response code="200">Success. Returns a case note related to the specified ID</response>
+        /// <response code="404">No case note found for the specified ID</response>
+        [ProducesResponseType(typeof(Boundary.Responses.CaseNoteInformation), StatusCodes.Status200OK)]
+        [HttpGet]
+        [Route("{caseNoteId}")]
+        public IActionResult GetCaseNote(long caseNoteId)
+        {
+            var caseNote = _getCaseNoteInformationByIdUseCase.Execute(caseNoteId);
+
+            if (caseNote == null) return NotFound();
+
+            return Ok(caseNote);
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Controllers/ResidentsController.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Controllers/ResidentsController.cs
@@ -11,14 +11,14 @@ namespace ResidentsSocialCarePlatformApi.V1.Controllers
     [Route("api/v1/residents")]
     [Produces("application/json")]
     [ApiVersion("1.0")]
-    public class SocialCareController : BaseController
+    public class ResidentsController : BaseController
     {
         private IGetAllResidentsUseCase _getAllResidentsUseCase;
         private IGetEntityByIdUseCase _getEntityByIdUseCase;
 
         private IGetAllCaseNotesUseCase _getAllCaseNotesUseCase;
 
-        public SocialCareController(IGetAllResidentsUseCase getAllResidentsUseCase, IGetEntityByIdUseCase getEntityByIdUseCase, IGetAllCaseNotesUseCase getAllCaseNotesUseCase)
+        public ResidentsController(IGetAllResidentsUseCase getAllResidentsUseCase, IGetEntityByIdUseCase getEntityByIdUseCase, IGetAllCaseNotesUseCase getAllCaseNotesUseCase)
         {
             _getAllResidentsUseCase = getAllResidentsUseCase;
             _getEntityByIdUseCase = getEntityByIdUseCase;


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

In the Interim Social Care System, we want to be able to display the details of a historic case note for a resident.

### *What changes have we introduced*

This PR adds a new controller action for getting a case note along with an end to end test.

It also renames the `SocialCareController` to `ResidentsController` because the `SocialCareController` has actions specific for a resident and we want to add a new route for getting a single case note information that looks like: `api/v1/case-notes/{caseNoteId}`. We can't to do this in the SocialCareController because it specifies the route `api/v1/residents` for it.

### *Follow up actions after merging PR*

- [x] Add new use case
- [x] Add new controller action with end to end test

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-523