### PR TITLE
Update Docker setup for testing and local development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ build:
 
 .PHONY: serve
 serve:
-	docker-compose build residents-social-care-platform-api
+	docker-compose build residents-social-care-platform-api && docker-compose up -d dev-database
 	-dotnet tool install -g dotnet-ef
 	CONNECTION_STRING="Host=127.0.0.1;Port=7654;Username=postgres;Password=mypassword;Database=socialcare" dotnet ef database update -p ResidentsSocialCarePlatformApi
 	docker-compose up residents-social-care-platform-api

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,10 @@ build:
 
 .PHONY: serve
 serve:
-	docker-compose build residents-social-care-platform-api && docker-compose up residents-social-care-platform-api
+	docker-compose build residents-social-care-platform-api
+	-dotnet tool install -g dotnet-ef
+	CONNECTION_STRING="Host=127.0.0.1;Port=7654;Username=postgres;Password=mypassword;Database=socialcare" dotnet ef database update -p ResidentsSocialCarePlatformApi
+	docker-compose up residents-social-care-platform-api
 
 .PHONY: shell
 shell:

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ restart-test-db:
 .PHONY: migrate-local-test-database
 migrate-local-test-database:
 	-dotnet tool install -g dotnet-ef
-	CONNECTION_STRING="Host=127.0.0.1;Port=6543;Username=postgres;Password=mypassword;Database=testsocialcare" dotnet ef database update -p ResidentsSocialCarePlatformApi
+	CONNECTION_STRING="Host=127.0.0.1;Port=6543;Username=postgres;Password=mypassword;Database=socialcare" dotnet ef database update -p ResidentsSocialCarePlatformApi
 
 .PHONY: lint
 lint:

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,8 @@ restart-test-db:
 	-docker rm $$container_id
 	docker-compose up -d test-database
 
-.PHONY: migrate-local-test-database
-migrate-local-test-database:
+.PHONY: migrate-test-db
+migrate-test-db:
 	-dotnet tool install -g dotnet-ef
 	CONNECTION_STRING="Host=127.0.0.1;Port=6543;Username=postgres;Password=mypassword;Database=socialcare" dotnet ef database update -p ResidentsSocialCarePlatformApi
 

--- a/README.md
+++ b/README.md
@@ -38,13 +38,18 @@ $ git clone git@github.com:LBHackney-IT/residents-social-care-platform-api.git
 
 ### Running the application
 
+#### With Docker
+
 To serve the API using Docker, use:
 
 ```sh
 $ make serve
 ```
 
-The application will be served at http://localhost:3000.
+The application will be served at http://localhost:3000 and expose the database
+at port `7654`.
+
+#### Without Docker
 
 To serve the API locally without Docker, use:
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If the migration file looks wrong or you have missed something, you can do eithe
 
 1. While the test database is running in the background, run:
    ```sh
-   $ CONNECTION_STRING="Host=127.0.0.1;Database=testsocialcare;Username=postgres;Password=mypassword;" dotnet ef migrations remove -p ResidentsSocialCarePlatformApi
+   $ CONNECTION_STRING="Host=127.0.0.1;Database=socialcare;Username=postgres;Password=mypassword;" dotnet ef migrations remove -p ResidentsSocialCarePlatformApi
    ```
 
 2. Or delete the migration files and revert the changes to `SocialCareContextModelSnapshot.cs`. Make the necessary changes to the context, then create the migration files again.
@@ -134,20 +134,20 @@ While running the test database locally (i.e you are able to run tests from with
 $ make migrate-local-test-database
 ```
 
-This will run migrations on the `testsocialcare` database on your local machine.
-(Your IDE connects to the `testsocialcare` database hosted on your localhost to run tests and not to the docker container).
+This will run migrations on the `socialcare` database on your local machine.
+(Your IDE connects to the `socialcare` database hosted on your localhost to run tests and not to the docker container).
 
 ### Troubleshooting Migrations
 If you encounter errors about tables already existing after running the `migrate-local-test-database` make command,
 you can try using [psql](https://www.postgresql.org/docs/current/app-psql.html)
-to delete all the existing tables in `dbo` schema and the `__EFMigrationsHistory` table from the `testsocialcare` database hosted on your localhost.
+to delete all the existing tables in `dbo` schema and the `__EFMigrationsHistory` table from the `socialcare` database hosted on your localhost.
 
-1. In your terminal, connect to the localhost instance of testsocialcare using psql:
+1. In your terminal, connect to the localhost instance of socialcare using psql:
 ```sh
-$ psql -h 127.0.0.1 -p 5432 -d testsocialcare -U postgres
+$ psql -h 127.0.0.1 -p 5432 -d socialcare -U postgres
 ```
 
-2. Delete all the tables in the testsocialcare `dbo` schema:
+2. Delete all the tables in the socialcare `dbo` schema:
 ```sh
 DROP SCHEMA IF EXISTS dbo CASCADE;
 ```

--- a/README.md
+++ b/README.md
@@ -130,15 +130,17 @@ Note: Any changes made to a `DbSet` or within `SocialCareContext` should have an
 ### Applying a Migration
 
 While running the test database locally (i.e you are able to run tests from within your IDE), run any new migrations with:
+
 ```sh
-$ make migrate-local-test-database
+$ make migrate-test-db
 ```
 
 This will run migrations on the `socialcare` database on your local machine.
 (Your IDE connects to the `socialcare` database hosted on your localhost to run tests and not to the docker container).
 
 ### Troubleshooting Migrations
-If you encounter errors about tables already existing after running the `migrate-local-test-database` make command,
+
+If you encounter errors about tables already existing after running the `migrate-test-db` make command,
 you can try using [psql](https://www.postgresql.org/docs/current/app-psql.html)
 to delete all the existing tables in `dbo` schema and the `__EFMigrationsHistory` table from the `socialcare` database hosted on your localhost.
 
@@ -163,7 +165,7 @@ N.B: Do not delete the public schema, if you do, you will need to recreate it us
 
 4. Exit the psql. You can use `\q`
 
-5. Run the `make migrate-local-test-database` command again.
+5. Run the `make migrate-test-db` command again.
    This should run the migrations on the database, create a new `__EFMigrationsHistory` table and save the new migration history there.
 
 ## Documentation

--- a/ResidentsSocialCarePlatformApi.Tests/ConnectionString.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/ConnectionString.cs
@@ -10,7 +10,7 @@ namespace ResidentsSocialCarePlatformApi.Tests
                    $"Port={Environment.GetEnvironmentVariable("DB_PORT") ?? "6543"};" +
                    $"Username={Environment.GetEnvironmentVariable("DB_USERNAME") ?? "postgres"};" +
                    $"Password={Environment.GetEnvironmentVariable("DB_PASSWORD") ?? "mypassword"};" +
-                   $"Database={Environment.GetEnvironmentVariable("DB_DATABASE") ?? "testsocialcare"}";
+                   $"Database={Environment.GetEnvironmentVariable("DB_DATABASE") ?? "socialcare"}";
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByPersonIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByPersonIdTests.cs
@@ -25,7 +25,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
             var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
             var convertedResponse = JsonConvert.DeserializeObject<List<VisitInformation>>(stringContent);
 
-            convertedResponse.Should().BeEquivalentTo(new List<VisitInformation>{visitInformation});
+            convertedResponse.Should().BeEquivalentTo(new List<VisitInformation> { visitInformation });
         }
 
         [Test]

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/VisitInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/VisitInformation.cs
@@ -9,9 +9,9 @@ namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 
         public string VisitType { get; set; } = null!;
 
-        public string? PlannedDateTime { get; set;  }
+        public string? PlannedDateTime { get; set; }
 
-        public string? ActualDateTime { get; set;  }
+        public string? ActualDateTime { get; set; }
 
         public string? ReasonNotPlanned { get; set; }
 

--- a/ResidentsSocialCarePlatformApi/V1/Domain/VisitInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Domain/VisitInformation.cs
@@ -11,9 +11,9 @@ namespace ResidentsSocialCarePlatformApi.V1.Domain
 
         public string VisitType { get; set; } = null!;
 
-        public DateTime? PlannedDateTime { get; set;  }
+        public DateTime? PlannedDateTime { get; set; }
 
-        public DateTime? ActualDateTime { get; set;  }
+        public DateTime? ActualDateTime { get; set; }
 
         public string? ReasonNotPlanned { get; set; }
 

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210325140637_UpdateCaseNoteColumnsTobeNullable.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210325140637_UpdateCaseNoteColumnsTobeNullable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210325141726_AddVisitsTable.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210325141726_AddVisitsTable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210325141809_AddOrganisationsTable.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210325141809_AddOrganisationsTable.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Visit.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Visit.cs
@@ -24,10 +24,10 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         public string VisitType { get; set; } = null!;
 
         [Column("planned_datetime")]
-        public DateTime? PlannedDateTime { get; set;  }
+        public DateTime? PlannedDateTime { get; set; }
 
         [Column("actual_datetime")]
-        public DateTime? ActualDateTime { get; set;  }
+        public DateTime? ActualDateTime { get; set; }
 
         [Column("reason_not_planned")]
         [StringLength(16)]

--- a/database.env
+++ b/database.env
@@ -1,3 +1,3 @@
 POSTGRES_USER=postgres
 POSTGRES_PASSWORD=mypassword
-POSTGRES_DB=testsocialcare
+POSTGRES_DB=socialcare

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
     links:
       - dev-database
   dev-database:
+    ports:
+      - 7654:5432
     env_file:
       - database.env
     image: postgres:12

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     ports:
       - 3000:3000
     environment:
-      - CONNECTION_STRING=Host=dev-database;Port=5432;Database=testsocialcare;Username=postgres;Password=mypassword
+      - CONNECTION_STRING=Host=dev-database;Port=5432;Database=socialcare;Username=postgres;Password=mypassword
     links:
       - dev-database
   dev-database:
@@ -27,7 +27,7 @@ services:
       - DB_PORT=5432
       - DB_USERNAME=postgres
       - DB_PASSWORD=mypassword
-      - DB_DATABASE=testsocialcare
+      - DB_DATABASE=socialcare
     links:
       - test-database
   test-database:


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

Our Docker setup for testing and local development is a bit out of sync and some naming doesn't quite align.

### *What changes have we introduced*

- Rename the database name for dev and test to `socialcare` instead of `testsocialcare` as this name is used for both dev and test, not just for testing due the setup using connection string etc.
- Rename Make command for migrating the test database from `make migrate-local-test-database` to `make migrate-test-db` to shorten and have aligned with other Make commands for the test database.
- Update docker-compose to expose dev database at port `7654` to allow us to easily access it from a Postgres client.
- Update the `make serve` command to run migrations for dev database.

### Guidance to review

Would recommend reviewing commit by commit.