### PR TITLE
Update list case notes endpoint

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -46,8 +46,11 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
             };
         }
 
-        public static Person AddPersonToDatabase(SocialCareContext context, long personId)
+        public static Person AddPersonToDatabase(SocialCareContext context)
         {
+            var faker = new Fixture();
+            var personId = faker.Create<CaseNote>().PersonId;
+
             var person = TestHelper.CreateDatabasePersonEntity(id: personId);
             context.Persons.Add(person);
             context.SaveChanges();
@@ -58,21 +61,47 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
         public static CaseNoteInformation AddCaseNoteForASpecificPersonToDb(SocialCareContext context, long personId)
         {
             var faker = new Fixture();
-            var caseNoteId = faker.Create<long>();
 
-            var caseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId);
+            var noteTypeCode = faker.Create<NoteType>().Type;
+            var noteTypeDescription = faker.Create<NoteType>().Description;
+            var savedNoteType = TestHelper.CreateDatabaseNoteType(noteTypeCode, noteTypeDescription);
+            context.NoteTypes.Add(savedNoteType);
 
-            context.CaseNotes.Add(caseNote);
+            var workerFirstName = faker.Create<Worker>().FirstNames;
+            var workerLastName = faker.Create<Worker>().LastNames;
+            var workerEmailAddress = faker.Create<Worker>().EmailAddress;
+            var workerSystemUserId = faker.Create<string>().Substring(0, 10);
+            var savedWorker = TestHelper.CreateDatabaseWorker(workerFirstName, workerLastName, workerEmailAddress, workerSystemUserId);
+            context.Workers.Add(savedWorker);
+
+            var caseNoteId = faker.Create<CaseNote>().Id;
+            var savedCaseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, savedNoteType.Type, savedWorker.SystemUserId, savedWorker.SystemUserId, savedWorker.SystemUserId);
+
+
+            context.CaseNotes.Add(savedCaseNote);
             context.SaveChanges();
 
             return new CaseNoteInformation
             {
-                MosaicId = personId.ToString(),
-                CaseNoteId = caseNote.Id,
-                CaseNoteTitle = caseNote.Title,
-                EffectiveDate = caseNote.EffectiveDate?.ToString("s"),
-                CreatedOn = caseNote.CreatedOn?.ToString("s"),
-                LastUpdatedOn = caseNote.LastUpdatedOn?.ToString("s")
+                MosaicId = savedCaseNote.PersonId.ToString(),
+                CaseNoteId = savedCaseNote.Id,
+                NoteType = savedNoteType.Description,
+                CaseNoteTitle = savedCaseNote.Title,
+                EffectiveDate = savedCaseNote.EffectiveDate?.ToString("s"),
+                CreatedOn = savedCaseNote.CreatedOn?.ToString("s"),
+                CreatedByName = $"{workerFirstName} {workerLastName}",
+                CreatedByEmail = workerEmailAddress,
+                LastUpdatedOn = savedCaseNote.LastUpdatedOn?.ToString("s"),
+                LastUpdatedName = $"{workerFirstName} {workerLastName}",
+                LastUpdatedEmail = workerEmailAddress,
+                CompletedDate = savedCaseNote.CompletedDate?.ToString("s"),
+                TimeoutDate = savedCaseNote.TimeoutDate?.ToString("s"),
+                CopyOfCaseNoteId = savedCaseNote.CopyOfCaseNoteId,
+                CopiedDate = savedCaseNote.CopiedDate?.ToString("s"),
+                CopiedByName = $"{workerFirstName} {workerLastName}",
+                CopiedByEmail = workerEmailAddress,
+                RootCaseNoteId = savedCaseNote.RootCaseNoteId,
+                PersonVisitId = savedCaseNote.PersonVisitId
             };
         }
 
@@ -108,7 +137,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
                 CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
                 CopiedDate = caseNote.CopiedDate?.ToString("s"),
                 CopiedByName = "Bow Archer",
-                CopiedByEmail = worker.EmailAddress,
+                CopiedByEmail = worker.EmailAddress
             };
         }
     }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/ListCaseNotesForAPerson.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/ListCaseNotesForAPerson.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 
 namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
 {
@@ -22,14 +23,14 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
         [Test]
         public async Task ReturnsAllCaseNotesForASpecificPerson()
         {
-            var personId = _fixture.Create<long>();
-            var person = E2ETestHelpers.AddPersonToDatabase(SocialCareContext, personId);
+
+            var person = E2ETestHelpers.AddPersonToDatabase(SocialCareContext);
 
             var expectedCaseNoteResponseOne = E2ETestHelpers.AddCaseNoteForASpecificPersonToDb(SocialCareContext, person.Id);
             var expectedCaseNoteResponseTwo = E2ETestHelpers.AddCaseNoteForASpecificPersonToDb(SocialCareContext, person.Id);
             var expectedCaseNoteResponseThree = E2ETestHelpers.AddCaseNoteForASpecificPersonToDb(SocialCareContext, person.Id);
 
-            var uri = new Uri($"api/v1/residents/{personId}/case-notes", UriKind.Relative);
+            var uri = new Uri($"api/v1/residents/{person.Id}/case-notes", UriKind.Relative);
             var response = Client.GetAsync(uri);
 
             var statusCode = response.Result.StatusCode;

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/ListCaseNotesForAPerson.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/ListCaseNotesForAPerson.cs
@@ -5,7 +5,6 @@ using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
-using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 
 namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
 {

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -111,10 +111,10 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
         public void CanMapCaseNoteInformationListFromDomainToResponse()
         {
             var recordOneTime = new DateTime(2020, 4, 1, 20, 30, 00);
-            const string formattedrecordOneTime = "2020-04-01T20:30:00";
+            const string formattedRecordOneTime = "2020-04-01T20:30:00";
 
             var recordTwoTime = new DateTime(1990, 11, 12, 10, 25, 00);
-            const string formattedrecordTwoTime = "1990-11-12T10:25:00";
+            const string formattedRecordTwoTime = "1990-11-12T10:25:00";
 
             var domain = new List<CaseNoteInformation>
             {
@@ -128,6 +128,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                     LastUpdatedOn = recordOneTime,
                     PersonVisitId = 456,
                     NoteType = "Case Summary (ASC)",
+                    CaseNoteContent = "",
                     CreatedByName = "Catra Grayskull",
                     CreatedByEmail = "catra@grayskull.com",
                     LastUpdatedName = "Catra Grayskull",
@@ -150,6 +151,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                     LastUpdatedOn = recordTwoTime,
                     PersonVisitId = 123,
                     NoteType = "Case Summary (ASC)",
+                    CaseNoteContent = "",
                     CreatedByName = "A Name goes here",
                     CreatedByEmail = "some@email.com",
                     LastUpdatedName = "A Name goes here",
@@ -171,20 +173,21 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                     MosaicId = "12345",
                     CaseNoteId = 67890,
                     CaseNoteTitle = "I AM A CASE NOTE",
-                    EffectiveDate = formattedrecordOneTime,
-                    CreatedOn = formattedrecordOneTime,
-                    LastUpdatedOn = formattedrecordOneTime,
+                    EffectiveDate = formattedRecordOneTime,
+                    CreatedOn = formattedRecordOneTime,
+                    LastUpdatedOn = formattedRecordOneTime,
                     PersonVisitId = 456,
                     NoteType = "Case Summary (ASC)",
+                    CaseNoteContent = "",
                     CreatedByName = "Catra Grayskull",
                     CreatedByEmail = "catra@grayskull.com",
                     LastUpdatedName = "Catra Grayskull",
                     LastUpdatedEmail = "catra@grayskull.com",
                     RootCaseNoteId = 789,
-                    CompletedDate = formattedrecordOneTime,
-                    TimeoutDate = formattedrecordOneTime,
+                    CompletedDate = formattedRecordOneTime,
+                    TimeoutDate = formattedRecordOneTime,
                     CopyOfCaseNoteId = 567,
-                    CopiedDate = formattedrecordOneTime,
+                    CopiedDate = formattedRecordOneTime,
                     CopiedByName = "Catra Grayskull",
                     CopiedByEmail = "catra@grayskull.com"
                 },
@@ -193,20 +196,21 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                     MosaicId = "12345",
                     CaseNoteId = 100000,
                     CaseNoteTitle = "I AM ANOTHER CASE NOTE",
-                    EffectiveDate = formattedrecordTwoTime,
-                    CreatedOn = formattedrecordTwoTime,
-                    LastUpdatedOn = formattedrecordTwoTime,
+                    EffectiveDate = formattedRecordTwoTime,
+                    CreatedOn = formattedRecordTwoTime,
+                    LastUpdatedOn = formattedRecordTwoTime,
                     PersonVisitId = 123,
                     NoteType = "Case Summary (ASC)",
+                    CaseNoteContent = "",
                     CreatedByName = "A Name goes here",
                     CreatedByEmail = "some@email.com",
                     LastUpdatedName = "A Name goes here",
                     LastUpdatedEmail = "some@email.com",
                     RootCaseNoteId = 456,
-                    CompletedDate = formattedrecordTwoTime,
-                    TimeoutDate = formattedrecordTwoTime,
+                    CompletedDate = formattedRecordTwoTime,
+                    TimeoutDate = formattedRecordTwoTime,
                     CopyOfCaseNoteId = 789,
-                    CopiedDate = formattedrecordTwoTime,
+                    CopiedDate = formattedRecordTwoTime,
                     CopiedByName = "This was copied",
                     CopiedByEmail = "copied@copy.com"
                 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -108,10 +108,13 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
         }
 
         [Test]
-        public void CanMapSummarisedCaseNoteInformationFromDomainToResponse()
+        public void CanMapCaseNoteInformationListFromDomainToResponse()
         {
-            var recordOneTime = new DateTime();
-            var recordTwoTime = new DateTime();
+            var recordOneTime = new DateTime(2020, 4, 1, 20, 30, 00);
+            const string formattedrecordOneTime = "2020-04-01T20:30:00";
+
+            var recordTwoTime = new DateTime(1990, 11, 12, 10, 25, 00);
+            const string formattedrecordTwoTime = "1990-11-12T10:25:00";
 
             var domain = new List<CaseNoteInformation>
             {
@@ -122,16 +125,42 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                     CaseNoteTitle = "I AM A CASE NOTE",
                     EffectiveDate = recordOneTime,
                     CreatedOn = recordOneTime,
-                    LastUpdatedOn = recordOneTime
+                    LastUpdatedOn = recordOneTime,
+                    PersonVisitId = 456,
+                    NoteType = "Case Summary (ASC)",
+                    CreatedByName = "Catra Grayskull",
+                    CreatedByEmail = "catra@grayskull.com",
+                    LastUpdatedName = "Catra Grayskull",
+                    LastUpdatedEmail = "catra@grayskull.com",
+                    RootCaseNoteId = 789,
+                    CompletedDate = recordOneTime,
+                    TimeoutDate = recordOneTime,
+                    CopyOfCaseNoteId = 567,
+                    CopiedDate = recordOneTime,
+                    CopiedByName = "Catra Grayskull",
+                    CopiedByEmail = "catra@grayskull.com"
                 },
                 new CaseNoteInformation
                 {
-                    MosaicId = "000000",
-                    CaseNoteId = 11111222,
+                    MosaicId = "12345",
+                    CaseNoteId = 100000,
                     CaseNoteTitle = "I AM ANOTHER CASE NOTE",
                     EffectiveDate = recordTwoTime,
                     CreatedOn = recordTwoTime,
-                    LastUpdatedOn = recordTwoTime
+                    LastUpdatedOn = recordTwoTime,
+                    PersonVisitId = 123,
+                    NoteType = "Case Summary (ASC)",
+                    CreatedByName = "A Name goes here",
+                    CreatedByEmail = "some@email.com",
+                    LastUpdatedName = "A Name goes here",
+                    LastUpdatedEmail = "some@email.com",
+                    RootCaseNoteId = 456,
+                    CompletedDate = recordTwoTime,
+                    TimeoutDate = recordTwoTime,
+                    CopyOfCaseNoteId = 789,
+                    CopiedDate = recordTwoTime,
+                    CopiedByName = "This was copied",
+                    CopiedByEmail = "copied@copy.com"
                 }
             };
 
@@ -142,18 +171,44 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                     MosaicId = "12345",
                     CaseNoteId = 67890,
                     CaseNoteTitle = "I AM A CASE NOTE",
-                    EffectiveDate = recordOneTime.ToString("s"),
-                    CreatedOn = recordOneTime.ToString("s"),
-                    LastUpdatedOn = recordOneTime.ToString("s")
+                    EffectiveDate = formattedrecordOneTime,
+                    CreatedOn = formattedrecordOneTime,
+                    LastUpdatedOn = formattedrecordOneTime,
+                    PersonVisitId = 456,
+                    NoteType = "Case Summary (ASC)",
+                    CreatedByName = "Catra Grayskull",
+                    CreatedByEmail = "catra@grayskull.com",
+                    LastUpdatedName = "Catra Grayskull",
+                    LastUpdatedEmail = "catra@grayskull.com",
+                    RootCaseNoteId = 789,
+                    CompletedDate = formattedrecordOneTime,
+                    TimeoutDate = formattedrecordOneTime,
+                    CopyOfCaseNoteId = 567,
+                    CopiedDate = formattedrecordOneTime,
+                    CopiedByName = "Catra Grayskull",
+                    CopiedByEmail = "catra@grayskull.com"
                 },
                 new CaseNoteInformationResponse
                 {
-                    MosaicId = "000000",
-                    CaseNoteId = 11111222,
+                    MosaicId = "12345",
+                    CaseNoteId = 100000,
                     CaseNoteTitle = "I AM ANOTHER CASE NOTE",
-                    EffectiveDate = recordTwoTime.ToString("s"),
-                    CreatedOn = recordTwoTime.ToString("s"),
-                    LastUpdatedOn = recordTwoTime.ToString("s")
+                    EffectiveDate = formattedrecordTwoTime,
+                    CreatedOn = formattedrecordTwoTime,
+                    LastUpdatedOn = formattedrecordTwoTime,
+                    PersonVisitId = 123,
+                    NoteType = "Case Summary (ASC)",
+                    CreatedByName = "A Name goes here",
+                    CreatedByEmail = "some@email.com",
+                    LastUpdatedName = "A Name goes here",
+                    LastUpdatedEmail = "some@email.com",
+                    RootCaseNoteId = 456,
+                    CompletedDate = formattedrecordTwoTime,
+                    TimeoutDate = formattedrecordTwoTime,
+                    CopyOfCaseNoteId = 789,
+                    CopiedDate = formattedrecordTwoTime,
+                    CopiedByName = "This was copied",
+                    CopiedByEmail = "copied@copy.com"
                 }
             };
 
@@ -187,7 +242,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                 CopyOfCaseNoteId = 567,
                 CopiedDate = dateTime,
                 CopiedByName = "Catra Grayskull",
-                CopiedByEmail = "catra@grayskull.com",
+                CopiedByEmail = "catra@grayskull.com"
             };
 
             var expectedResponse = new CaseNoteInformationResponse
@@ -211,7 +266,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                 CopyOfCaseNoteId = 567,
                 CopiedDate = formattedDateTime,
                 CopiedByName = "Catra Grayskull",
-                CopiedByEmail = "catra@grayskull.com",
+                CopiedByEmail = "catra@grayskull.com"
             };
 
             domain.ToResponse().Should().BeEquivalentTo(expectedResponse);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllCaseNotesUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllCaseNotesUseCaseTests.cs
@@ -31,7 +31,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
             var noRecords = new List<CaseNoteInformation>();
 
             _mockSocialCareGateway.Setup(x =>
-                    x.GetCaseNotes(34567))
+                    x.GetAllCaseNotes(34567))
                 .Returns(noRecords);
 
             var response = _classUnderTest.Execute(34567);
@@ -45,7 +45,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
             var stubbedCaseNotes = _fixture.CreateMany<CaseNoteInformation>();
 
             _mockSocialCareGateway.Setup(x =>
-                    x.GetCaseNotes(34567))
+                    x.GetAllCaseNotes(34567))
                 .Returns(stubbedCaseNotes.ToList());
 
             var response = _classUnderTest.Execute(34567);

--- a/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
@@ -49,22 +49,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
             };
         }
 
-        public static List<CaseNoteInformation> ToDomain(this IEnumerable<CaseNote> caseNotes)
-        {
-            return caseNotes
-                .Select(
-                    caseNote => new CaseNoteInformation
-                    {
-                        MosaicId = caseNote.PersonId.ToString(),
-                        CaseNoteId = caseNote.Id,
-                        CaseNoteTitle = caseNote.Title,
-                        EffectiveDate = caseNote.EffectiveDate,
-                        CreatedOn = caseNote.CreatedOn,
-                        LastUpdatedOn = caseNote.LastUpdatedOn
-                    }
-                ).ToList();
-        }
-
         public static CaseNoteInformation ToDomain(this CaseNote caseNote)
         {
             return new CaseNoteInformation

--- a/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
@@ -64,10 +64,23 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
             {
                 MosaicId = caseNote.MosaicId,
                 CaseNoteId = caseNote.CaseNoteId,
+                NoteType = caseNote.NoteType,
                 CaseNoteTitle = caseNote.CaseNoteTitle,
                 EffectiveDate = caseNote.EffectiveDate?.ToString("s"),
                 CreatedOn = caseNote.CreatedOn?.ToString("s"),
-                LastUpdatedOn = caseNote.LastUpdatedOn?.ToString("s")
+                CreatedByName = caseNote.CreatedByName,
+                CreatedByEmail = caseNote.CreatedByEmail,
+                LastUpdatedOn = caseNote.LastUpdatedOn?.ToString("s"),
+                LastUpdatedName = caseNote.LastUpdatedName,
+                LastUpdatedEmail = caseNote.LastUpdatedEmail,
+                CompletedDate = caseNote.CompletedDate?.ToString("s"),
+                TimeoutDate = caseNote.TimeoutDate?.ToString("s"),
+                RootCaseNoteId = caseNote.RootCaseNoteId,
+                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
+                CopiedDate = caseNote.CopiedDate?.ToString("s"),
+                CopiedByName = caseNote.CopiedByName,
+                CopiedByEmail = caseNote.CopiedByEmail,
+                PersonVisitId = caseNote.PersonVisitId
             }).ToList();
         }
 

--- a/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
@@ -60,28 +60,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
 
         public static List<Boundary.Responses.CaseNoteInformation> ToResponse(this IEnumerable<Domain.CaseNoteInformation> caseNotes)
         {
-            return caseNotes.Select(caseNote => new Boundary.Responses.CaseNoteInformation
-            {
-                MosaicId = caseNote.MosaicId,
-                CaseNoteId = caseNote.CaseNoteId,
-                NoteType = caseNote.NoteType,
-                CaseNoteTitle = caseNote.CaseNoteTitle,
-                EffectiveDate = caseNote.EffectiveDate?.ToString("s"),
-                CreatedOn = caseNote.CreatedOn?.ToString("s"),
-                CreatedByName = caseNote.CreatedByName,
-                CreatedByEmail = caseNote.CreatedByEmail,
-                LastUpdatedOn = caseNote.LastUpdatedOn?.ToString("s"),
-                LastUpdatedName = caseNote.LastUpdatedName,
-                LastUpdatedEmail = caseNote.LastUpdatedEmail,
-                CompletedDate = caseNote.CompletedDate?.ToString("s"),
-                TimeoutDate = caseNote.TimeoutDate?.ToString("s"),
-                RootCaseNoteId = caseNote.RootCaseNoteId,
-                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
-                CopiedDate = caseNote.CopiedDate?.ToString("s"),
-                CopiedByName = caseNote.CopiedByName,
-                CopiedByEmail = caseNote.CopiedByEmail,
-                PersonVisitId = caseNote.PersonVisitId
-            }).ToList();
+            return caseNotes.Select(caseNote => caseNote.ToResponse()).ToList();
         }
 
         private static List<Phone> ToResponse(this List<PhoneNumber> phoneNumbers)

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/ISocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/ISocialCareGateway.cs
@@ -11,7 +11,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
 
         Domain.ResidentInformation InsertResident(string firstName, string lastName);
 
-        List<Domain.CaseNoteInformation> GetCaseNotes(long personId);
+        List<Domain.CaseNoteInformation> GetAllCaseNotes(long personId);
 
         Domain.CaseNoteInformation GetCaseNoteInformationById(long caseNoteId);
     }

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -1,7 +1,7 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.EntityFrameworkCore;
+using ResidentsSocialCarePlatformApi.V1.Domain;
 using ResidentsSocialCarePlatformApi.V1.Factories;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 
@@ -84,32 +84,11 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
             };
         }
 
-        public List<Domain.CaseNoteInformation> GetCaseNotes(long personId)
+        public List<CaseNoteInformation> GetAllCaseNotes(long personId)
         {
             var caseNotes = _socialCareContext.CaseNotes.Where(note => note.PersonId == personId).ToList();
 
-            return caseNotes.Select(caseNote => new Domain.CaseNoteInformation
-            {
-                MosaicId = caseNote.PersonId.ToString(),
-                CaseNoteId = caseNote.Id,
-                NoteType = LookUpNoteTypeDescription(caseNote.NoteType),
-                CaseNoteTitle = caseNote.Title,
-                EffectiveDate = caseNote.EffectiveDate,
-                CreatedOn = caseNote.CreatedOn,
-                CreatedByName = GetWorkerName(caseNote.CreatedBy),
-                CreatedByEmail = GetWorkerEmailAddress(caseNote.CreatedBy),
-                LastUpdatedOn = caseNote.LastUpdatedOn,
-                LastUpdatedName = GetWorkerName(caseNote.LastUpdatedBy),
-                LastUpdatedEmail = GetWorkerEmailAddress(caseNote.LastUpdatedBy),
-                CompletedDate = caseNote.CompletedDate,
-                TimeoutDate = caseNote.TimeoutDate,
-                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
-                CopiedDate = caseNote.CopiedDate,
-                CopiedByName = GetWorkerName(caseNote.CopiedBy),
-                CopiedByEmail = GetWorkerEmailAddress(caseNote.CopiedBy),
-                RootCaseNoteId = caseNote.RootCaseNoteId,
-                PersonVisitId = caseNote.PersonVisitId
-            }).ToList();
+            return caseNotes.Select(AddRelatedInformationToCaseNote).ToList();
         }
 
         public Domain.CaseNoteInformation GetCaseNoteInformationById(long caseNoteId)
@@ -262,6 +241,25 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
         {
             return _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId.Equals(actionDoneById))
                 ?.EmailAddress;
+        }
+
+        private CaseNoteInformation AddRelatedInformationToCaseNote(CaseNote caseNote)
+        {
+            var caseNoteInformation = caseNote.ToDomain();
+            caseNoteInformation.CaseNoteContent = null;
+
+            caseNoteInformation.NoteType = LookUpNoteTypeDescription(caseNote.NoteType);
+
+            caseNoteInformation.CreatedByName = GetWorkerName(caseNote.CreatedBy);
+            caseNoteInformation.CreatedByEmail = GetWorkerEmailAddress(caseNote.CreatedBy);
+
+            caseNoteInformation.LastUpdatedName = GetWorkerName(caseNote.LastUpdatedBy);
+            caseNoteInformation.LastUpdatedEmail = GetWorkerEmailAddress(caseNote.LastUpdatedBy);
+
+            caseNoteInformation.CopiedByName = GetWorkerName(caseNote.CopiedBy);
+            caseNoteInformation.CopiedByEmail = GetWorkerEmailAddress(caseNote.CopiedBy);
+
+            return caseNoteInformation;
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -86,9 +86,30 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
 
         public List<Domain.CaseNoteInformation> GetCaseNotes(long personId)
         {
-            return _socialCareContext.CaseNotes
-                .Where(note => note.PersonId == personId).ToDomain()
-                .ToList();
+            var caseNotes = _socialCareContext.CaseNotes.Where(note => note.PersonId == personId).ToList();
+
+            return caseNotes.Select(caseNote => new Domain.CaseNoteInformation
+            {
+                MosaicId = caseNote.PersonId.ToString(),
+                CaseNoteId = caseNote.Id,
+                NoteType = LookUpNoteTypeDescription(caseNote.NoteType),
+                CaseNoteTitle = caseNote.Title,
+                EffectiveDate = caseNote.EffectiveDate,
+                CreatedOn = caseNote.CreatedOn,
+                CreatedByName = GetWorkerName(caseNote.CreatedBy),
+                CreatedByEmail = GetWorkerEmailAddress(caseNote.CreatedBy),
+                LastUpdatedOn = caseNote.LastUpdatedOn,
+                LastUpdatedName = GetWorkerName(caseNote.LastUpdatedBy),
+                LastUpdatedEmail = GetWorkerEmailAddress(caseNote.LastUpdatedBy),
+                CompletedDate = caseNote.CompletedDate,
+                TimeoutDate = caseNote.TimeoutDate,
+                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
+                CopiedDate = caseNote.CopiedDate,
+                CopiedByName = GetWorkerName(caseNote.CopiedBy),
+                CopiedByEmail = GetWorkerEmailAddress(caseNote.CopiedBy),
+                RootCaseNoteId = caseNote.RootCaseNoteId,
+                PersonVisitId = caseNote.PersonVisitId
+            }).ToList();
         }
 
         public Domain.CaseNoteInformation GetCaseNoteInformationById(long caseNoteId)
@@ -223,6 +244,24 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
         private static string GetSearchPattern(string str)
         {
             return $"%{str?.Replace(" ", "")}%";
+        }
+
+        private string LookUpNoteTypeDescription(string noteTypeCode)
+        {
+            return _socialCareContext.NoteTypes.FirstOrDefault(type => type.Type.Equals(noteTypeCode))?.Description;
+        }
+
+
+        private string GetWorkerName(string actionDoneById)
+        {
+            var worker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId.Equals(actionDoneById));
+            return worker != null ? $"{worker.FirstNames} {worker.LastNames}" : null;
+        }
+
+        private string GetWorkerEmailAddress(string actionDoneById)
+        {
+            return _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId.Equals(actionDoneById))
+                ?.EmailAddress;
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/GetAllCaseNotesUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/GetAllCaseNotesUseCase.cs
@@ -16,7 +16,7 @@ namespace ResidentsSocialCarePlatformApi.V1.UseCase
 
         public CaseNoteInformationList Execute(long personId)
         {
-            var caseNotes = _socialCareGateway.GetCaseNotes(personId);
+            var caseNotes = _socialCareGateway.GetAllCaseNotes(personId);
 
             return new CaseNoteInformationList
             {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-540

### *What is the problem we're trying to solve*

We wanted to get an early iteration of the LIST case note endpoint working end-to-end and so created the gateway to return an object with only a few properties.

We have been able to successfully test the endpoint end-to-end. 🎉 

We need to update the object returned to have more information about a case note (e.g related workers, etc) and not the few simple properties we had for the first iteration.

### *What changes have we introduced*

This PR modifies the LIST case note gateway to return case note information objects without the `CaseNoteContent`.

Decided not to return the `CaseNoteContent` as part of the listing as these are written with HTML tags and can be very long.

#### _Checklist_

- [X] Added end-to-end (i.e. integration) tests where necessary e.g to test the complete functionality of a newly added feature
- [X] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add a link to documentation)_, where necessary.
- [X] Checked all code for possible refactoring
- [X] Code pipeline builds correctly

### *Follow up actions after merging PR*

Test the updated endpoint in production.
Add swagger documentation to describe the API
