### PR TITLE
Fix incorrect subnets for Mosaic-Production in serverless config

### DIFF
--- a/ResidentsSocialCarePlatformApi/serverless.yml
+++ b/ResidentsSocialCarePlatformApi/serverless.yml
@@ -93,5 +93,5 @@ custom:
       securityGroupIds:
         - sg-048f37056608033d3
       subnetIds:
-        - subnet-0665104ee973a21be
-        - subnet-005b74d8082f68a84
+        - subnet-0c39cd286eeaff2b2
+        - subnet-04c42d0aafb3738ad


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

In AWS, the subnets have been set as these but in our serverless config
they are not i.e. there is a mismatch. However, this should not change
anything as this is already set as these values.

### *What changes have we introduced*

This PR updates the subnets to match what is already in AWS.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCS-666
