### PR TITLE
Get historic records for resident

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
@@ -183,7 +183,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
         {
             const long fakerPersonId = 123L;
             var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse().ToSharedResponse(fakerPersonId);
-            var residentRecords = new List<ResidentHistoricRecord> {visit};
+            var residentRecords = new List<ResidentHistoricRecord> { visit };
             _mockGetResidentRecordsUseCase.Setup(x => x.Execute(fakerPersonId)).Returns(residentRecords);
 
             var response = _classUnderTest.GetResidentRecords(fakerPersonId) as OkObjectResult;
@@ -202,7 +202,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
         {
             const long fakerPersonId = 123L;
             var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse().ToSharedResponse(fakerPersonId);
-            var residentRecords = new List<ResidentHistoricRecord> {caseNote};
+            var residentRecords = new List<ResidentHistoricRecord> { caseNote };
             _mockGetResidentRecordsUseCase.Setup(x => x.Execute(fakerPersonId)).Returns(residentRecords);
 
             var response = _classUnderTest.GetResidentRecords(fakerPersonId) as OkObjectResult;
@@ -222,7 +222,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
             const long fakerPersonId = 123L;
             var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse().ToSharedResponse(fakerPersonId);
             var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse().ToSharedResponse(fakerPersonId);
-            var residentRecords = new List<ResidentHistoricRecord> {visit, caseNote};
+            var residentRecords = new List<ResidentHistoricRecord> { visit, caseNote };
             _mockGetResidentRecordsUseCase.Setup(x => x.Execute(fakerPersonId)).Returns(residentRecords);
 
             var response = _classUnderTest.GetResidentRecords(fakerPersonId) as OkObjectResult;

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetResidentRecords.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetResidentRecords.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.V1.Factories;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+
+
+namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
+{
+    [TestFixture]
+    public class GetResidentRecords : EndToEndTests<Startup>
+    {
+        [Test]
+        public async Task WhenThereIsAVisitWithMatchingPersonId_Returns200AndResidentRecords()
+        {
+            var visit = E2ETestHelpers.AddVisitToDatabase(SocialCareContext);
+            var visitResponse = visit.ToDomain().ToResponse().ToSharedResponse(visit.PersonId);
+            var uri = new Uri($"api/v1/residents/{visit.PersonId}/records", UriKind.Relative);
+
+            var response = Client.GetAsync(uri);
+
+            response.Result.StatusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<List<ResidentHistoricRecord>>(stringContent);
+
+            convertedResponse.Should().BeEquivalentTo(new List<ResidentHistoricRecord> { visitResponse });
+        }
+
+        [Test]
+        public async Task WhenThereIsACaseNoteWithMatchingPersonId_Returns200AndResidentRecords()
+        {
+            var person = E2ETestHelpers.AddPersonToDatabase(SocialCareContext);
+            var caseNote = E2ETestHelpers.AddCaseNoteForASpecificPersonToDb(SocialCareContext, person.Id);
+            var caseNotesResponse = caseNote.ToSharedResponse(person.Id);
+            var uri = new Uri($"api/v1/residents/{person.Id}/records", UriKind.Relative);
+
+            var response = Client.GetAsync(uri);
+
+            response.Result.StatusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<List<ResidentHistoricRecord>>(stringContent);
+
+            convertedResponse.Should().BeEquivalentTo(new List<ResidentHistoricRecord> { caseNotesResponse });
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -5,6 +5,7 @@ using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
 using ResidentsSocialCarePlatformApi.V1.Domain;
 using ResidentsSocialCarePlatformApi.V1.Factories;
 using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.Tests.V1.Helper;
 using Address = ResidentsSocialCarePlatformApi.V1.Domain.Address;
 using CaseNoteInformation = ResidentsSocialCarePlatformApi.V1.Domain.CaseNoteInformation;
 using ResidentInformation = ResidentsSocialCarePlatformApi.V1.Domain.ResidentInformation;
@@ -274,6 +275,58 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
             };
 
             domain.ToResponse().Should().BeEquivalentTo(expectedResponse);
+        }
+
+        [Test]
+        public void CanMapVisitInformationToSharedToResidentHistoricRecordVisit()
+        {
+            var person = TestHelper.CreateDatabasePersonEntity();
+            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse();
+
+            var residentHistoricRecordVisit = new ResidentHistoricRecordVisit
+            {
+                RecordId = visit.VisitId,
+                FormName = "",
+                PersonId = person.Id,
+                FirstName = "",
+                LastName = "",
+                DateOfBirth = "",
+                OfficerEmail = visit.CreatedByEmail,
+                CaseFormUrl = "",
+                CaseFormTimeStamp = "",
+                DateOfEvent = visit.ActualDateTime ?? visit.PlannedDateTime,
+                CaseNoteTitle = "",
+                RecordType = RecordType.Visit,
+                Visit = visit
+            };
+
+            visit.ToSharedResponse(person.Id).Should().BeEquivalentTo(residentHistoricRecordVisit);
+        }
+
+        [Test]
+        public void CanMapCaseNoteInformationToSharedToResidentHistoricRecordCaseNote()
+        {
+            var person = TestHelper.CreateDatabasePersonEntity();
+            var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse();
+
+            var residentHistoricRecordCaseNote = new ResidentHistoricRecordCaseNote
+            {
+                RecordId = caseNote.CaseNoteId,
+                FormName = "",
+                PersonId = person.Id,
+                FirstName = "",
+                LastName = "",
+                DateOfBirth = "",
+                OfficerEmail = caseNote.CopiedByEmail,
+                CaseFormUrl = "",
+                CaseFormTimeStamp = "",
+                DateOfEvent = caseNote.CompletedDate,
+                CaseNoteTitle = caseNote.CaseNoteTitle,
+                RecordType = RecordType.Visit,
+                CaseNote = caseNote
+            };
+
+            caseNote.ToSharedResponse(person.Id).Should().BeEquivalentTo(caseNote.ToSharedResponse(person.Id));
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetResidentRecordsUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetResidentRecordsUseCaseTests.cs
@@ -31,7 +31,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         {
             const long fakePersonId = 123L;
             var visits = new List<VisitInformation>();
-            var caseNotes = new CaseNoteInformationList {CaseNotes = new List<CaseNoteInformation>()};
+            var caseNotes = new CaseNoteInformationList { CaseNotes = new List<CaseNoteInformation>() };
             _mockGetVisitInformationByPersonId.Setup(x => x.Execute(fakePersonId)).Returns(visits);
             _mockGetAllCaseNotesUseCase.Setup(x => x.Execute(fakePersonId)).Returns(caseNotes);
 
@@ -45,8 +45,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         {
             const long fakePersonId = 123L;
             var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse();
-            var visits = new List<VisitInformation>{visit};
-            var caseNotes = new CaseNoteInformationList {CaseNotes = new List<CaseNoteInformation>()};
+            var visits = new List<VisitInformation> { visit };
+            var caseNotes = new CaseNoteInformationList { CaseNotes = new List<CaseNoteInformation>() };
             _mockGetVisitInformationByPersonId.Setup(x => x.Execute(fakePersonId)).Returns(visits);
             _mockGetAllCaseNotesUseCase.Setup(x => x.Execute(fakePersonId)).Returns(caseNotes);
 
@@ -62,7 +62,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
             const long fakePersonId = 123L;
             var visits = new List<VisitInformation>();
             var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse();
-            var caseNotes = new CaseNoteInformationList {CaseNotes = new List<CaseNoteInformation>{caseNote}};
+            var caseNotes = new CaseNoteInformationList { CaseNotes = new List<CaseNoteInformation> { caseNote } };
             _mockGetVisitInformationByPersonId.Setup(x => x.Execute(fakePersonId)).Returns(visits);
             _mockGetAllCaseNotesUseCase.Setup(x => x.Execute(fakePersonId)).Returns(caseNotes);
 
@@ -77,9 +77,9 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         {
             const long fakePersonId = 123L;
             var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse();
-            var visits = new List<VisitInformation>{visit};
+            var visits = new List<VisitInformation> { visit };
             var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse();
-            var caseNotes = new CaseNoteInformationList {CaseNotes = new List<CaseNoteInformation>{caseNote}};
+            var caseNotes = new CaseNoteInformationList { CaseNotes = new List<CaseNoteInformation> { caseNote } };
             _mockGetVisitInformationByPersonId.Setup(x => x.Execute(fakePersonId)).Returns(visits);
             _mockGetAllCaseNotesUseCase.Setup(x => x.Execute(fakePersonId)).Returns(caseNotes);
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetResidentRecordsUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetResidentRecordsUseCaseTests.cs
@@ -1,0 +1,93 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.Tests.V1.Helper;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+using ResidentsSocialCarePlatformApi.V1.Factories;
+using ResidentsSocialCarePlatformApi.V1.UseCase;
+using ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces;
+
+namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
+{
+    public class GetResidentRecordsUseCaseTests
+    {
+        private Mock<IGetVisitInformationByPersonId> _mockGetVisitInformationByPersonId = null!;
+        private Mock<IGetAllCaseNotesUseCase> _mockGetAllCaseNotesUseCase = null!;
+        private GetResidentRecordsUseCase _classUnderTest = null!;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _mockGetVisitInformationByPersonId = new Mock<IGetVisitInformationByPersonId>();
+            _mockGetAllCaseNotesUseCase = new Mock<IGetAllCaseNotesUseCase>();
+            _classUnderTest = new GetResidentRecordsUseCase(
+                _mockGetVisitInformationByPersonId.Object,
+                _mockGetAllCaseNotesUseCase.Object);
+        }
+
+        [Test]
+        public void WhenThereIsNoCaseNotesOrVisits_ReturnEmptyList()
+        {
+            const long fakePersonId = 123L;
+            var visits = new List<VisitInformation>();
+            var caseNotes = new CaseNoteInformationList {CaseNotes = new List<CaseNoteInformation>()};
+            _mockGetVisitInformationByPersonId.Setup(x => x.Execute(fakePersonId)).Returns(visits);
+            _mockGetAllCaseNotesUseCase.Setup(x => x.Execute(fakePersonId)).Returns(caseNotes);
+
+            var response = _classUnderTest.Execute(fakePersonId);
+
+            response.Should().BeEmpty();
+        }
+
+        [Test]
+        public void WhenThereIsVisits_ReturnListWithVisits()
+        {
+            const long fakePersonId = 123L;
+            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse();
+            var visits = new List<VisitInformation>{visit};
+            var caseNotes = new CaseNoteInformationList {CaseNotes = new List<CaseNoteInformation>()};
+            _mockGetVisitInformationByPersonId.Setup(x => x.Execute(fakePersonId)).Returns(visits);
+            _mockGetAllCaseNotesUseCase.Setup(x => x.Execute(fakePersonId)).Returns(caseNotes);
+
+            var response = _classUnderTest.Execute(fakePersonId);
+
+            response.Count.Should().Be(visits.Count);
+            response.Should().BeEquivalentTo(visit.ToResponse());
+        }
+
+        [Test]
+        public void WhenThereIsCaseNotes_ReturnListWithVisits()
+        {
+            const long fakePersonId = 123L;
+            var visits = new List<VisitInformation>();
+            var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse();
+            var caseNotes = new CaseNoteInformationList {CaseNotes = new List<CaseNoteInformation>{caseNote}};
+            _mockGetVisitInformationByPersonId.Setup(x => x.Execute(fakePersonId)).Returns(visits);
+            _mockGetAllCaseNotesUseCase.Setup(x => x.Execute(fakePersonId)).Returns(caseNotes);
+
+            var response = _classUnderTest.Execute(fakePersonId);
+
+            response.Count.Should().Be(caseNotes.CaseNotes.Count);
+            response.Should().BeEquivalentTo(caseNote.ToResponse());
+        }
+
+        [Test]
+        public void WhenThereIsCaseNotesAndVisits_ReturnListWithBoth()
+        {
+            const long fakePersonId = 123L;
+            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse();
+            var visits = new List<VisitInformation>{visit};
+            var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse();
+            var caseNotes = new CaseNoteInformationList {CaseNotes = new List<CaseNoteInformation>{caseNote}};
+            _mockGetVisitInformationByPersonId.Setup(x => x.Execute(fakePersonId)).Returns(visits);
+            _mockGetAllCaseNotesUseCase.Setup(x => x.Execute(fakePersonId)).Returns(caseNotes);
+
+            var response = _classUnderTest.Execute(fakePersonId);
+
+            response.Count.Should().Be(caseNotes.CaseNotes.Count + visits.Count);
+            response[0].Should().BeEquivalentTo(visit.ToResponse());
+            response[1].Should().BeEquivalentTo(caseNote.ToResponse());
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetResidentRecordsUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetResidentRecordsUseCaseTests.cs
@@ -53,7 +53,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
             var response = _classUnderTest.Execute(fakePersonId);
 
             response.Count.Should().Be(visits.Count);
-            response.Should().BeEquivalentTo(visit.ToResponse());
+            response.Should().BeEquivalentTo(visit.ToSharedResponse(fakePersonId));
         }
 
         [Test]
@@ -69,7 +69,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
             var response = _classUnderTest.Execute(fakePersonId);
 
             response.Count.Should().Be(caseNotes.CaseNotes.Count);
-            response.Should().BeEquivalentTo(caseNote.ToResponse());
+            response.Should().BeEquivalentTo(caseNote.ToSharedResponse(fakePersonId));
         }
 
         [Test]
@@ -86,8 +86,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
             var response = _classUnderTest.Execute(fakePersonId);
 
             response.Count.Should().Be(caseNotes.CaseNotes.Count + visits.Count);
-            response[0].Should().BeEquivalentTo(visit.ToResponse());
-            response[1].Should().BeEquivalentTo(caseNote.ToResponse());
+            response[0].Should().BeEquivalentTo(visit.ToSharedResponse(fakePersonId));
+            response[1].Should().BeEquivalentTo(caseNote.ToSharedResponse(fakePersonId));
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi/Startup.cs
+++ b/ResidentsSocialCarePlatformApi/Startup.cs
@@ -136,6 +136,7 @@ namespace ResidentsSocialCarePlatformApi
             services.AddScoped<IGetCaseNoteInformationByIdUseCase, GetCaseNoteInformationByIdUseCase>();
             services.AddScoped<IGetVisitInformationByPersonId, GetVisitInformationByPersonId>();
             services.AddScoped<IGetVisitInformationByVisitId, GetVisitInformationByVisitId>();
+            services.AddScoped<IGetResidentRecordsUseCase, GetResidentRecordsUseCase>();
             services.AddScoped<IValidatePostcode, ValidatePostcode>();
         }
 

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecord.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecord.cs
@@ -1,0 +1,17 @@
+namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
+{
+    public class ResidentHistoricRecord
+    {
+        public long MosaicId { get; set; }
+
+        public RecordType RecordType { get; set; }
+
+        public string CaseNoteTitle { get; set; }
+    }
+
+    public enum RecordType
+    {
+        CaseNote,
+        Visit
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecord.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecord.cs
@@ -1,12 +1,33 @@
+#nullable enable
 namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 {
     public class ResidentHistoricRecord
     {
-        public long MosaicId { get; set; }
+        public long RecordId { get; set; }
+
+        public string? FormName { get; set; }
+
+        public long PersonId { get; set; }
+
+        public string? FirstName { get; set; }
+
+        public string? LastName { get; set; }
+
+        public string? DateOfBirth { get; set; }
+
+        public string? OfficerEmail { get; set; }
+
+        public string? CaseFormUrl { get; set; }
+
+        public string? CaseFormTimeStamp { get; set; }
+
+        public string? DateOfEvent { get; set; }
+
+        public string? CaseNoteTitle { get; set; }
 
         public RecordType RecordType { get; set; }
 
-        public string CaseNoteTitle { get; set; }
+        public bool isHistoric { get; set; } = true;
     }
 
     public enum RecordType

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecord.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecord.cs
@@ -27,7 +27,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 
         public RecordType RecordType { get; set; }
 
-        public bool isHistoric { get; set; } = true;
+        public bool IsHistoric { get; set; } = true;
     }
 
     public enum RecordType

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecordCaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecordCaseNote.cs
@@ -1,0 +1,7 @@
+namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
+{
+    public class ResidentHistoricRecordCaseNote : ResidentHistoricRecord
+    {
+        private CaseNoteInformation CaseNote { get; set; }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecordCaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecordCaseNote.cs
@@ -1,7 +1,8 @@
+#nullable enable
 namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 {
     public class ResidentHistoricRecordCaseNote : ResidentHistoricRecord
     {
-        private CaseNoteInformation CaseNote { get; set; }
+        public CaseNoteInformation CaseNote { get; set; } = null!;
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecordVisit.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecordVisit.cs
@@ -1,0 +1,7 @@
+namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
+{
+    public class ResidentHistoricRecordVisit : ResidentHistoricRecord
+    {
+        private VisitInformation Visit { get; set; }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecordVisit.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/ResidentHistoricRecordVisit.cs
@@ -1,7 +1,9 @@
+#nullable enable
+
 namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
 {
     public class ResidentHistoricRecordVisit : ResidentHistoricRecord
     {
-        private VisitInformation Visit { get; set; }
+        public VisitInformation Visit { get; set; } = null!;
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Controllers/ResidentsController.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Controllers/ResidentsController.cs
@@ -14,22 +14,25 @@ namespace ResidentsSocialCarePlatformApi.V1.Controllers
     [ApiVersion("1.0")]
     public class ResidentsController : BaseController
     {
-        private IGetAllResidentsUseCase _getAllResidentsUseCase;
-        private IGetEntityByIdUseCase _getEntityByIdUseCase;
-        private IGetAllCaseNotesUseCase _getAllCaseNotesUseCase;
+        private readonly IGetAllResidentsUseCase _getAllResidentsUseCase;
+        private readonly IGetEntityByIdUseCase _getEntityByIdUseCase;
+        private readonly IGetAllCaseNotesUseCase _getAllCaseNotesUseCase;
         private readonly IGetVisitInformationByPersonId _getVisitInformationByPersonId;
+        private readonly IGetResidentRecordsUseCase _getResidentRecordsUseCase;
 
         public ResidentsController(
             IGetAllResidentsUseCase getAllResidentsUseCase,
             IGetEntityByIdUseCase getEntityByIdUseCase,
             IGetAllCaseNotesUseCase getAllCaseNotesUseCase,
-            IGetVisitInformationByPersonId getVisitInformationByPersonId
+            IGetVisitInformationByPersonId getVisitInformationByPersonId,
+            IGetResidentRecordsUseCase getResidentRecordsUseCase
             )
         {
             _getAllResidentsUseCase = getAllResidentsUseCase;
             _getEntityByIdUseCase = getEntityByIdUseCase;
             _getAllCaseNotesUseCase = getAllCaseNotesUseCase;
             _getVisitInformationByPersonId = getVisitInformationByPersonId;
+            _getResidentRecordsUseCase = getResidentRecordsUseCase;
         }
 
         /// <summary>
@@ -72,10 +75,21 @@ namespace ResidentsSocialCarePlatformApi.V1.Controllers
         }
 
         /// /// <summary>
+        /// Returns list of historic records for a Person ID
+        /// </summary>
+        /// <response code="200">Success. Returns a list of record information for a resident</response>
+        [ProducesResponseType(typeof(CaseNoteInformationList), StatusCodes.Status200OK)]
+        [HttpGet]
+        [Route("{personId}/records")]
+        public IActionResult GetResidentRecords(long personId)
+        {
+            return Ok(_getResidentRecordsUseCase.Execute(personId));
+        }
+
+        /// /// <summary>
         /// Returns list of cases notes for a Person/Mosaic ID
         /// </summary>
         /// <response code="200">Success. Returns a list of matching case note information</response>
-        // TO DO: Error Handling & responses????
         [ProducesResponseType(typeof(CaseNoteInformationList), StatusCodes.Status200OK)]
         [HttpGet]
         [Route("{personId}/case-notes")]

--- a/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
@@ -112,5 +112,24 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 CreatedByEmail = visit.CreatedByEmail
             };
         }
+
+        public static ResidentHistoricRecordVisit ToResponse(this Boundary.Responses.VisitInformation visit)
+        {
+            return new ResidentHistoricRecordVisit
+            {
+                MosaicId = visit.PersonId,
+                RecordType = RecordType.Visit
+
+            };
+        }
+
+        public static ResidentHistoricRecordCaseNote ToResponse(this Boundary.Responses.CaseNoteInformation visit)
+        {
+            return new ResidentHistoricRecordCaseNote
+            {
+                MosaicId = long.Parse(visit.MosaicId),
+                RecordType = RecordType.CaseNote
+            };
+        }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Linq;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
 using ResidentsSocialCarePlatformApi.V1.Domain;
+using ResidentsSocialCarePlatformApi.V1.UseCase;
 
 namespace ResidentsSocialCarePlatformApi.V1.Factories
 {
@@ -113,22 +114,43 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
             };
         }
 
-        public static ResidentHistoricRecordVisit ToResponse(this Boundary.Responses.VisitInformation visit)
+        public static ResidentHistoricRecordVisit ToSharedResponse(this Boundary.Responses.VisitInformation visit, long personId)
         {
             return new ResidentHistoricRecordVisit
             {
-                MosaicId = visit.PersonId,
-                RecordType = RecordType.Visit
-
+                RecordId = visit.VisitId,
+                FormName = "",
+                PersonId = personId,
+                FirstName = "",
+                LastName = "",
+                DateOfBirth = "",
+                OfficerEmail = visit.CreatedByEmail,
+                CaseFormUrl = "",
+                CaseFormTimeStamp = "",
+                DateOfEvent = visit.ActualDateTime ?? visit.PlannedDateTime,
+                CaseNoteTitle = "",
+                RecordType = RecordType.Visit,
+                Visit = visit
             };
         }
 
-        public static ResidentHistoricRecordCaseNote ToResponse(this Boundary.Responses.CaseNoteInformation visit)
+        public static ResidentHistoricRecordCaseNote ToSharedResponse(this Boundary.Responses.CaseNoteInformation caseNote, long personId)
         {
             return new ResidentHistoricRecordCaseNote
             {
-                MosaicId = long.Parse(visit.MosaicId),
-                RecordType = RecordType.CaseNote
+                RecordId = caseNote.CaseNoteId,
+                FormName = "",
+                PersonId = personId,
+                FirstName = "",
+                LastName = "",
+                DateOfBirth = "",
+                OfficerEmail = caseNote.CreatedByEmail,
+                CaseFormUrl = "",
+                CaseFormTimeStamp = "",
+                DateOfEvent = caseNote.CompletedDate,
+                CaseNoteTitle = "",
+                RecordType = RecordType.CaseNote,
+                CaseNote = caseNote
             };
         }
     }

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/GetResidentRecordsUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/GetResidentRecordsUseCase.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+using System.Linq;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+using ResidentsSocialCarePlatformApi.V1.Factories;
+using ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces;
+
+namespace ResidentsSocialCarePlatformApi.V1.UseCase
+{
+    public class GetResidentRecordsUseCase : IGetResidentRecordsUseCase
+    {
+        private readonly IGetVisitInformationByPersonId _getVisitInformationByPersonId;
+        private readonly IGetAllCaseNotesUseCase _getAllCaseNotesUseCase;
+
+        public GetResidentRecordsUseCase(
+            IGetVisitInformationByPersonId getVisitInformationByPersonId,
+            IGetAllCaseNotesUseCase getAllCaseNotesUseCase)
+        {
+            _getVisitInformationByPersonId = getVisitInformationByPersonId;
+            _getAllCaseNotesUseCase = getAllCaseNotesUseCase;
+        }
+
+        public List<ResidentHistoricRecord> Execute(long personId)
+        {
+            var visits = _getVisitInformationByPersonId.Execute(personId);
+            var caseNotes = _getAllCaseNotesUseCase.Execute(personId).CaseNotes;
+
+            var visitRecords = (from visit in visits select visit.ToResponse()).ToList();
+            var caseNoteRecords = (from caseNote in caseNotes select caseNote.ToResponse()).ToList();
+
+            var residentHistoricRecords = new List<ResidentHistoricRecord>();
+
+            residentHistoricRecords.AddRange(visitRecords.Cast<ResidentHistoricRecord>());
+            residentHistoricRecords.AddRange(caseNoteRecords.Cast<ResidentHistoricRecord>());
+
+            return residentHistoricRecords;
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/GetResidentRecordsUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/GetResidentRecordsUseCase.cs
@@ -24,8 +24,8 @@ namespace ResidentsSocialCarePlatformApi.V1.UseCase
             var visits = _getVisitInformationByPersonId.Execute(personId);
             var caseNotes = _getAllCaseNotesUseCase.Execute(personId).CaseNotes;
 
-            var visitRecords = (from visit in visits select visit.ToResponse()).ToList();
-            var caseNoteRecords = (from caseNote in caseNotes select caseNote.ToResponse()).ToList();
+            var visitRecords = (from visit in visits select visit.ToSharedResponse(personId)).ToList();
+            var caseNoteRecords = (from caseNote in caseNotes select caseNote.ToSharedResponse(personId)).ToList();
 
             var residentHistoricRecords = new List<ResidentHistoricRecord>();
 

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/Interfaces/IGetResidentRecordsUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/Interfaces/IGetResidentRecordsUseCase.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+
+namespace ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces
+{
+    public interface IGetResidentRecordsUseCase
+    {
+        List<ResidentHistoricRecord> Execute(long personId);
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

This doesn't really have a jira ticket because initial titles on jira tickets didn't accurately describe the problem being solved.

[Relevant Jira Epic ticket](https://hackney.atlassian.net/jira/software/projects/SCS/boards/51/roadmap?selectedIssue=SCS-488)

## Describe this PR

### *What is the problem we're trying to solve*

Single API route that when accessed with a person (resident) id we return all their historic records (at the moment case note and visits).

Service API will call this API and then return to the data to https://social-care-service-staging.hackney.gov.uk/people/2 (Shown under Records History section)

### *What changes have we introduced*

Created a single API route for getting both historic visits and case notes for a resident.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Call from service API.
