### PR TITLE
feat(SCT-202): Add API endpoint for getting relationships

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/EndToEndTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/EndToEndTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Net.Http;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Storage;
@@ -42,6 +43,26 @@ namespace ResidentsSocialCarePlatformApi.Tests
             _client = _factory.CreateClient();
             _socialCareContext = new SocialCareContext(_builder.Options);
             _socialCareContext.Database.EnsureCreated();
+
+            // Temporary fix until we can get migrations running in our pipeline
+            var createPersonalRelationshipsSql = String.Join(
+                Environment.NewLine,
+                "CREATE OR REPLACE VIEW dbo.vw_personal_relationships AS",
+                "SELECT dpr.personal_relationship_id, dpr.person_id, dpr.other_person_id, dprt.description,",
+                "CASE",
+                "WHEN dprt.family_category = 'Child''s Children' THEN 'children'",
+                "WHEN dprt.family_category = 'Child''s Siblings' THEN 'siblings'",
+                "WHEN dprt.family_category = 'Child''s Parents' THEN 'parents'",
+                "WHEN dprt.family_category = 'Other Family Relationships' THEN 'other'",
+                "WHEN dprt.family_category IS NULL THEN 'other'",
+                "ELSE 'unknown'",
+                "END AS category",
+                "FROM",
+                "dbo.dm_personal_relationships dpr",
+                "INNER JOIN dbo.dm_personal_rel_types dprt ON dpr.personal_rel_type_id = dprt.personal_rel_type_id;");
+
+            _socialCareContext.Database.ExecuteSqlRaw(createPersonalRelationshipsSql);
+
             _transaction = SocialCareContext.Database.BeginTransaction();
         }
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Boundary/Requests/GetRelationshipsRequestTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Boundary/Requests/GetRelationshipsRequestTests.cs
@@ -1,0 +1,44 @@
+using Bogus;
+using FluentAssertions;
+using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
+
+namespace ResidentsSocialCarePlatformApi.Tests.V1.Boundary.Request
+{
+    [TestFixture]
+    public class GetRelationshipsRequestTests
+    {
+        private GetRelationshipsRequestValidator _classUnderTest;
+        private Faker _faker;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _faker = new Faker();
+            _classUnderTest = new GetRelationshipsRequestValidator();
+        }
+
+        [Test]
+        public void WhenPersonIdIsInvalid_ReturnsAnError()
+        {
+            var badGetRelationshipsRequest = new GetRelationshipsRequest() { PersonId = 0 };
+
+            var response = _classUnderTest.Validate(badGetRelationshipsRequest);
+
+            response.Should().NotBeNull();
+            response.IsValid.Should().Be(false);
+            response.ToString().Should().Be("Person ID must be greater than 0");
+        }
+
+        [Test]
+        public void WhenPersonIdIsProvided_ReturnsItIsValid()
+        {
+            var validGetRelationshipsRequest = new GetRelationshipsRequest() { PersonId = 123456789 };
+
+            var response = _classUnderTest.Validate(validGetRelationshipsRequest);
+
+            response.Should().NotBeNull();
+            response.IsValid.Should().Be(true);
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
@@ -23,6 +23,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
         private Mock<IGetAllCaseNotesUseCase> _mockGetAllCaseNotesUseCase;
         private Mock<IGetVisitInformationByPersonId> _mockGetVisitInformationByPersonIdUseCase;
         private Mock<IGetResidentRecordsUseCase> _mockGetResidentRecordsUseCase;
+        private Mock<IGetRelationshipsByPersonIdUseCase> _mockGetRelationIGetRelationshipsByPersonIdUseCase;
 
         [SetUp]
         public void SetUp()
@@ -32,13 +33,15 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
             _mockGetAllCaseNotesUseCase = new Mock<IGetAllCaseNotesUseCase>();
             _mockGetVisitInformationByPersonIdUseCase = new Mock<IGetVisitInformationByPersonId>();
             _mockGetResidentRecordsUseCase = new Mock<IGetResidentRecordsUseCase>();
+            _mockGetRelationIGetRelationshipsByPersonIdUseCase = new Mock<IGetRelationshipsByPersonIdUseCase>();
 
             _classUnderTest = new ResidentsController(
                 _mockGetAllResidentsUseCase.Object,
                 _mockGetEntityByIdUseCase.Object,
                 _mockGetAllCaseNotesUseCase.Object,
                 _mockGetVisitInformationByPersonIdUseCase.Object,
-                _mockGetResidentRecordsUseCase.Object);
+                _mockGetResidentRecordsUseCase.Object,
+                _mockGetRelationIGetRelationshipsByPersonIdUseCase.Object);
         }
 
         [Test]
@@ -234,6 +237,30 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
 
             response.StatusCode.Should().Be(200);
             response.Value.Should().BeEquivalentTo(residentRecords);
+        }
+
+        [Test]
+        public void GetRelationships_WhenThereInvalidPersonIdIsProvided_Returns400()
+        {
+            var getRelationshipsRequest = new GetRelationshipsRequest() { PersonId = 0 };
+
+            var response = _classUnderTest.GetRelationships(getRelationshipsRequest) as BadRequestObjectResult;
+
+            response.StatusCode.Should().Be(400);
+            response.Value.Should().Be("Person ID must be greater than 0");
+        }
+
+        [Test]
+        public void GetRelationships_WhenThereIsAPersonId_ReturnRelationship()
+        {
+            var getRelationshipsRequest = new GetRelationshipsRequest() { PersonId = 123456789 };
+            var relationships = new Relationships();
+            _mockGetRelationIGetRelationshipsByPersonIdUseCase.Setup(x => x.Execute(It.IsAny<GetRelationshipsRequest>())).Returns(relationships);
+
+            var response = _classUnderTest.GetRelationships(getRelationshipsRequest) as OkObjectResult;
+
+            response.StatusCode.Should().Be(200);
+            response.Value.Should().BeEquivalentTo(relationships);
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -156,6 +156,34 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
 
             return worker;
         }
-    }
 
+        public static (Person, Person, Person) AddPersonalRelationshipsToDatabase(SocialCareContext socialCareContext, string familyCategory = "Child's Parents")
+        {
+            var person = TestHelper.CreateDatabasePersonEntity(id: 1);
+            var otherPerson1 = TestHelper.CreateDatabasePersonEntity(id: 2);
+            var otherPerson2 = TestHelper.CreateDatabasePersonEntity(id: 3);
+            var personalRelationshipType = TestHelper.CreatePersonalRelationshipType(familyCategory: familyCategory);
+            var personalRelationship1 = TestHelper.CreatePersonalRelationship(
+                personId: person.Id,
+                personalRelTypeId: personalRelationshipType.PersonalRelationshipTypeId,
+                otherPersonId: otherPerson1.Id
+            );
+            var personalRelationship2 = TestHelper.CreatePersonalRelationship(
+                personId: person.Id,
+                personalRelTypeId: personalRelationshipType.PersonalRelationshipTypeId,
+                otherPersonId: otherPerson2.Id
+            );
+
+            socialCareContext.Persons.Add(person);
+            socialCareContext.Persons.Add(otherPerson1);
+            socialCareContext.Persons.Add(otherPerson2);
+            socialCareContext.PersonalRelationshipTypes.Add(personalRelationshipType);
+            socialCareContext.PersonalRelationships.Add(personalRelationship1);
+            socialCareContext.PersonalRelationships.Add(personalRelationship2);
+
+            socialCareContext.SaveChanges();
+
+            return (person, otherPerson1, otherPerson2);
+        }
+    }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetRelationshipsByPersonIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetRelationshipsByPersonIdTests.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using NUnit.Framework;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
+using ResidentsSocialCarePlatformApi.V1.Factories;
+
+namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
+{
+    [TestFixture]
+    public class GetRelationshipsByPersonIdTests : EndToEndTests<Startup>
+    {
+        [Test]
+        public async Task WhenThereArePersonalRelationships_Returns200AndRelationships()
+        {
+            var (person, otherPerson1, otherPerson2) = E2ETestHelpers.AddPersonalRelationshipsToDatabase(SocialCareContext, familyCategory: "Child's Parents");
+            var uri = new Uri($"api/v1/residents/{person.Id}/relationships", UriKind.Relative);
+
+            var response = Client.GetAsync(uri);
+
+            response.Result.StatusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<Relationships>(stringContent);
+
+            convertedResponse.PersonId.Should().Be(person.Id);
+            convertedResponse.PersonalRelationships.Parents.Should().Contain(otherPerson1.Id);
+            convertedResponse.PersonalRelationships.Parents.Should().Contain(otherPerson2.Id);
+            convertedResponse.PersonalRelationships.Children.Should().BeEmpty();
+            convertedResponse.PersonalRelationships.Siblings.Should().BeEmpty();
+            convertedResponse.PersonalRelationships.Other.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task WhenThereAreNoPersonalRelationships_Returns200AndEmptyLists()
+        {
+            var person = E2ETestHelpers.AddPersonToDatabase(SocialCareContext);
+            var uri = new Uri($"api/v1/residents/{person.Id}/relationships", UriKind.Relative);
+
+            var response = Client.GetAsync(uri);
+
+            response.Result.StatusCode.Should().Be(200);
+
+            var content = response.Result.Content;
+            var stringContent = await content.ReadAsStringAsync().ConfigureAwait(true);
+            var convertedResponse = JsonConvert.DeserializeObject<Relationships>(stringContent);
+
+            convertedResponse.PersonId.Should().Be(person.Id);
+            convertedResponse.PersonalRelationships.Parents.Should().BeEmpty();
+            convertedResponse.PersonalRelationships.Children.Should().BeEmpty();
+            convertedResponse.PersonalRelationships.Siblings.Should().BeEmpty();
+            convertedResponse.PersonalRelationships.Other.Should().BeEmpty();
+        }
+
+        [Test]
+        public async Task WhenThereIsAnInvalidPersonId_Returns400()
+        {
+            var invalidPersonId = 0;
+            var uri = new Uri($"api/v1/residents/{invalidPersonId}/relationships", UriKind.Relative);
+
+            var response = Client.GetAsync(uri);
+
+            response.Result.StatusCode.Should().Be(400);
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -178,7 +178,6 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .RuleFor(personalRelationship => personalRelationship.Children, f => Enumerable.Range(0, f.Random.Int(0, 5)).Select(x => f.PickRandom(new List<long>() { f.UniqueIndex, f.UniqueIndex, f.UniqueIndex })).ToList())
                 .RuleFor(personalRelationship => personalRelationship.Siblings, f => Enumerable.Range(0, f.Random.Int(0, 5)).Select(x => f.PickRandom(new List<long>() { f.UniqueIndex, f.UniqueIndex, f.UniqueIndex })).ToList())
                 .RuleFor(personalRelationship => personalRelationship.Other, f => Enumerable.Range(0, f.Random.Int(0, 5)).Select(x => f.PickRandom(new List<long>() { f.UniqueIndex, f.UniqueIndex, f.UniqueIndex })).ToList());
-
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetRelationshipsByPersonIdUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetRelationshipsByPersonIdUseCaseTests.cs
@@ -32,8 +32,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
 
             var response = _classUnderTest.Execute(request);
 
-            response.PersonId.Equals(request.PersonId);
-
+            response.PersonId.Should().Be(request.PersonId);
             response.PersonalRelationships.Parents.Should().BeEmpty();
             response.PersonalRelationships.Siblings.Should().BeEmpty();
             response.PersonalRelationships.Children.Should().BeEmpty();
@@ -49,8 +48,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
 
             var response = _classUnderTest.Execute(request);
 
-            response.PersonId.Equals(request.PersonId);
-
+            response.PersonId.Should().Be(request.PersonId);
             response.PersonalRelationships.Parents.Should().NotBeEmpty();
             response.PersonalRelationships.Siblings.Should().NotBeEmpty();
             response.PersonalRelationships.Children.Should().NotBeEmpty();
@@ -66,8 +64,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
 
             var response = _classUnderTest.Execute(request);
 
-            response.PersonId.Equals(request.PersonId);
-
+            response.PersonId.Should().Be(request.PersonId);
             response.PersonalRelationships.Parents.Should().Equal(matchingRelationships.Parents);
             response.PersonalRelationships.Siblings.Should().Equal(matchingRelationships.Siblings);
             response.PersonalRelationships.Children.Should().Equal(matchingRelationships.Children);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetRelationshipsByPersonIdUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetRelationshipsByPersonIdUseCaseTests.cs
@@ -2,6 +2,7 @@ using AutoFixture;
 using Moq;
 using NUnit.Framework;
 using FluentAssertions;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
 using ResidentsSocialCarePlatformApi.V1.Domain;
 using ResidentsSocialCarePlatformApi.V1.Gateways;
 using ResidentsSocialCarePlatformApi.V1.UseCase;
@@ -25,12 +26,13 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void WhenThereAreNoPersonalRelationships_ReturnsEmptyLists()
         {
+            var request = new GetRelationshipsRequest() { PersonId = 123456789 };
             PersonalRelationships noMatchingRelationships = new PersonalRelationships();
-            _mockSocialCareGateway.Setup(x => x.GetPersonalRelationships(123)).Returns(noMatchingRelationships);
+            _mockSocialCareGateway.Setup(x => x.GetPersonalRelationships(It.IsAny<long>())).Returns(noMatchingRelationships);
 
-            var response = _classUnderTest.Execute(123);
+            var response = _classUnderTest.Execute(request);
 
-            response.PersonId.Equals(123);
+            response.PersonId.Equals(request.PersonId);
 
             response.PersonalRelationships.Parents.Should().BeEmpty();
             response.PersonalRelationships.Siblings.Should().BeEmpty();
@@ -41,12 +43,13 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void WhenThereArePersonalRelationships_ReturnsListOfIDs()
         {
+            var request = new GetRelationshipsRequest() { PersonId = 123456789 };
             PersonalRelationships matchingRelationships = _fixture.Create<PersonalRelationships>();
-            _mockSocialCareGateway.Setup(x => x.GetPersonalRelationships(123)).Returns(matchingRelationships);
+            _mockSocialCareGateway.Setup(x => x.GetPersonalRelationships(It.IsAny<long>())).Returns(matchingRelationships);
 
-            var response = _classUnderTest.Execute(123);
+            var response = _classUnderTest.Execute(request);
 
-            response.PersonId.Equals(123);
+            response.PersonId.Equals(request.PersonId);
 
             response.PersonalRelationships.Parents.Should().NotBeEmpty();
             response.PersonalRelationships.Siblings.Should().NotBeEmpty();
@@ -57,12 +60,13 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void WhenThereAreSomePersonalRelationships_ReturnsListOfIDs()
         {
+            var request = new GetRelationshipsRequest() { PersonId = 123456789 };
             var matchingRelationships = TestHelper.CreateRandomPersonalRelationship();
-            _mockSocialCareGateway.Setup(x => x.GetPersonalRelationships(123)).Returns(matchingRelationships);
+            _mockSocialCareGateway.Setup(x => x.GetPersonalRelationships(It.IsAny<long>())).Returns(matchingRelationships);
 
-            var response = _classUnderTest.Execute(123);
+            var response = _classUnderTest.Execute(request);
 
-            response.PersonId.Equals(123);
+            response.PersonId.Equals(request.PersonId);
 
             response.PersonalRelationships.Parents.Should().Equal(matchingRelationships.Parents);
             response.PersonalRelationships.Siblings.Should().Equal(matchingRelationships.Siblings);

--- a/ResidentsSocialCarePlatformApi/ResidentsSocialCarePlatformApi.csproj
+++ b/ResidentsSocialCarePlatformApi/ResidentsSocialCarePlatformApi.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.7.3" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.3" />
     <PackageReference Include="AWSXRayRecorder.Handlers.EntityFramework" Version="1.1.1" />
+    <PackageReference Include="FluentValidation.AspNetCore" Version="10.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />

--- a/ResidentsSocialCarePlatformApi/Startup.cs
+++ b/ResidentsSocialCarePlatformApi/Startup.cs
@@ -15,12 +15,14 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.OpenApi.Models;
 using ResidentsSocialCarePlatformApi.Versioning;
 using Newtonsoft.Json.Converters;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
 using ResidentsSocialCarePlatformApi.V1.Gateways;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 using ResidentsSocialCarePlatformApi.V1.UseCase;
 using ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces;
 using Swashbuckle.AspNetCore.SwaggerGen;
 using Amazon.XRay.Recorder.Handlers.AwsSdk;
+using FluentValidation;
 
 namespace ResidentsSocialCarePlatformApi
 {
@@ -113,6 +115,7 @@ namespace ResidentsSocialCarePlatformApi
             ConfigureDbContext(services);
             RegisterGateways(services);
             RegisterUseCases(services);
+            RegisterValidators(services);
         }
 
         private static void ConfigureDbContext(IServiceCollection services)
@@ -142,6 +145,11 @@ namespace ResidentsSocialCarePlatformApi
             services.AddScoped<IGetResidentRecordsUseCase, GetResidentRecordsUseCase>();
             services.AddScoped<IGetRelationshipsByPersonIdUseCase, GetRelationshipsByPersonIdUseCase>();
             services.AddScoped<IValidatePostcode, ValidatePostcode>();
+        }
+
+        private static void RegisterValidators(IServiceCollection services)
+        {
+            services.AddTransient<IValidator<GetRelationshipsRequest>, GetRelationshipsRequestValidator>();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/ResidentsSocialCarePlatformApi/Startup.cs
+++ b/ResidentsSocialCarePlatformApi/Startup.cs
@@ -140,6 +140,7 @@ namespace ResidentsSocialCarePlatformApi
             services.AddScoped<IGetVisitInformationByPersonId, GetVisitInformationByPersonId>();
             services.AddScoped<IGetVisitInformationByVisitId, GetVisitInformationByVisitId>();
             services.AddScoped<IGetResidentRecordsUseCase, GetResidentRecordsUseCase>();
+            services.AddScoped<IGetRelationshipsByPersonIdUseCase, GetRelationshipsByPersonIdUseCase>();
             services.AddScoped<IValidatePostcode, ValidatePostcode>();
         }
 

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Requests/GetRelationshipsRequest.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Requests/GetRelationshipsRequest.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+using FluentValidation;
+using Microsoft.AspNetCore.Mvc;
+
+namespace ResidentsSocialCarePlatformApi.V1.Boundary.Requests
+{
+    public class GetRelationshipsRequest
+    {
+        [FromRoute]
+        public long PersonId { get; set; }
+    }
+
+    public class GetRelationshipsRequestValidator : AbstractValidator<GetRelationshipsRequest>
+    {
+        public GetRelationshipsRequestValidator()
+        {
+            RuleFor(getRelationshipsRequest => getRelationshipsRequest.PersonId)
+                .NotNull().WithMessage("Person ID must be provided")
+                .GreaterThan(0).WithMessage("Person ID must be greater than 0");
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Controllers/ResidentsController.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Controllers/ResidentsController.cs
@@ -19,13 +19,15 @@ namespace ResidentsSocialCarePlatformApi.V1.Controllers
         private readonly IGetAllCaseNotesUseCase _getAllCaseNotesUseCase;
         private readonly IGetVisitInformationByPersonId _getVisitInformationByPersonId;
         private readonly IGetResidentRecordsUseCase _getResidentRecordsUseCase;
+        private readonly IGetRelationshipsByPersonIdUseCase _getRelationIGetRelationshipsByPersonIdUseCase;
 
         public ResidentsController(
             IGetAllResidentsUseCase getAllResidentsUseCase,
             IGetEntityByIdUseCase getEntityByIdUseCase,
             IGetAllCaseNotesUseCase getAllCaseNotesUseCase,
             IGetVisitInformationByPersonId getVisitInformationByPersonId,
-            IGetResidentRecordsUseCase getResidentRecordsUseCase
+            IGetResidentRecordsUseCase getResidentRecordsUseCase,
+            IGetRelationshipsByPersonIdUseCase getRelationIGetRelationshipsByPersonIdUseCase
             )
         {
             _getAllResidentsUseCase = getAllResidentsUseCase;
@@ -33,6 +35,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Controllers
             _getAllCaseNotesUseCase = getAllCaseNotesUseCase;
             _getVisitInformationByPersonId = getVisitInformationByPersonId;
             _getResidentRecordsUseCase = getResidentRecordsUseCase;
+            _getRelationIGetRelationshipsByPersonIdUseCase = getRelationIGetRelationshipsByPersonIdUseCase;
         }
 
         /// <summary>
@@ -113,6 +116,29 @@ namespace ResidentsSocialCarePlatformApi.V1.Controllers
             if (visitInformation.Count == 0) return NotFound();
 
             return Ok(visitInformation);
+        }
+
+        /// /// <summary>
+        /// Get relationships for a person
+        /// </summary>
+        /// <response code="200">Success. Returns relationships for a person</response>
+        /// <response code="400">Invalid person ID</response>
+        [ProducesResponseType(typeof(Boundary.Responses.Relationships), StatusCodes.Status200OK)]
+        [HttpGet]
+        [Route("{personId}/relationships")]
+        public IActionResult GetRelationships([FromQuery] GetRelationshipsRequest request)
+        {
+            var validator = new GetRelationshipsRequestValidator();
+            var validationResults = validator.Validate(request);
+
+            if (!validationResults.IsValid)
+            {
+                return BadRequest(validationResults.ToString());
+            }
+
+            var relationships = _getRelationIGetRelationshipsByPersonIdUseCase.Execute(request);
+
+            return Ok(relationships);
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/GetRelationshipsByPersonIdUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/GetRelationshipsByPersonIdUseCase.cs
@@ -1,4 +1,4 @@
-using System;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
 using ResidentsSocialCarePlatformApi.V1.Gateways;
 using ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces;
@@ -14,13 +14,13 @@ namespace ResidentsSocialCarePlatformApi.V1.UseCase
             _socialCareGateway = socialCareGateway;
         }
 
-        public Relationships Execute(long personId)
+        public Relationships Execute(GetRelationshipsRequest request)
         {
-            var personalRelationships = _socialCareGateway.GetPersonalRelationships(personId);
+            var personalRelationships = _socialCareGateway.GetPersonalRelationships(request.PersonId);
 
             return new Relationships()
             {
-                PersonId = personId,
+                PersonId = request.PersonId,
                 PersonalRelationships = personalRelationships
             };
         }

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/Interfaces/IGetRelationshipsByPersonIdUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/Interfaces/IGetRelationshipsByPersonIdUseCase.cs
@@ -1,10 +1,11 @@
 using System;
+using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
 
 namespace ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces
 {
     public interface IGetRelationshipsByPersonIdUseCase
     {
-        Relationships Execute(long personId);
+        Relationships Execute(GetRelationshipsRequest request);
     }
 }


### PR DESCRIPTION
## Describe this PR

### *What is the problem we're trying to solve*

We want to expose historic relationships in the Social Care System. In #27, #28 and #30 we've been building up to create a new endpoint to return a response like:

```json
{
  "personId": 987654321,
  "personalRelationships": {
    "parents": [
      123456789,
      234567891
    ],
    "siblings": [
      345678912,
      456789123
    ],
    "children": [
      567891234,
      678912345
    ],
    "other": [
      789123456,
      891234567
    ]
  }
}
```

### *What changes have we introduced*

This PR adds the actual API endpoint for getting relationships with some end to end tests. It also refactors the `GetRelationshipsByPersonId` use case to use a boundary request object.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Deploy and test the relationships end to test.

## Link to JIRA ticket

https://hackney.atlassian.net/browse/SCT-202
