### PR TITLE
Sct 1124/optimise fetching historic visits and historic case notes

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/DatabaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/DatabaseTests.cs
@@ -21,6 +21,7 @@ namespace ResidentsSocialCarePlatformApi.Tests
         {
             _builder = new DbContextOptionsBuilder();
             _builder.UseNpgsql(ConnectionString.TestDatabase());
+            _builder.EnableDetailedErrors();
         }
 
         [SetUp]

--- a/ResidentsSocialCarePlatformApi.Tests/EndToEndTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/EndToEndTests.cs
@@ -34,6 +34,7 @@ namespace ResidentsSocialCarePlatformApi.Tests
 
             _builder = new DbContextOptionsBuilder();
             _builder.UseNpgsql(_connection);
+            _builder.EnableDetailedErrors();
         }
 
         [SetUp]

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Boundary/Requests/GetRelationshipsRequestTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Boundary/Requests/GetRelationshipsRequestTests.cs
@@ -1,20 +1,17 @@
-using Bogus;
 using FluentAssertions;
 using NUnit.Framework;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
 
-namespace ResidentsSocialCarePlatformApi.Tests.V1.Boundary.Request
+namespace ResidentsSocialCarePlatformApi.Tests.V1.Boundary.Requests
 {
     [TestFixture]
     public class GetRelationshipsRequestTests
     {
         private GetRelationshipsRequestValidator _classUnderTest;
-        private Faker _faker;
 
         [SetUp]
         public void SetUp()
         {
-            _faker = new Faker();
             _classUnderTest = new GetRelationshipsRequestValidator();
         }
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/CaseNotesControllerTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/CaseNotesControllerTests.cs
@@ -1,14 +1,10 @@
-using System;
-using System.Collections.Generic;
 using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Moq;
-using ResidentsSocialCarePlatformApi.V1.Boundary.Requests;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
 using ResidentsSocialCarePlatformApi.V1.Controllers;
 using ResidentsSocialCarePlatformApi.V1.UseCase.Interfaces;
 using NUnit.Framework;
-using ResidentInformation = ResidentsSocialCarePlatformApi.V1.Boundary.Responses.ResidentInformation;
 
 namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
 {
@@ -33,43 +29,30 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
             var caseNoteInformation = new CaseNoteInformation
             {
                 MosaicId = "12345",
-                CaseNoteId = 67890,
+                CaseNoteId = "67890",
                 CaseNoteTitle = "I AM A CASE NOTE",
-                EffectiveDate = formattedDateTime,
                 CreatedOn = formattedDateTime,
-                LastUpdatedOn = formattedDateTime,
-                PersonVisitId = 456,
                 NoteType = "Case Summary (ASC)",
                 CreatedByName = "Finn Grayskull",
                 CreatedByEmail = "finn@grayskull.com",
-                LastUpdatedName = "Finn Grayskull",
-                LastUpdatedEmail = "finn@grayskull.com",
                 CaseNoteContent = "I am case note content.",
-                RootCaseNoteId = 789,
-                CompletedDate = formattedDateTime,
-                TimeoutDate = formattedDateTime,
-                CopyOfCaseNoteId = 567,
-                CopiedDate = formattedDateTime,
-                CopiedByName = "Finn Grayskull",
-                CopiedByEmail = "finn@grayskull.com",
             };
             _mockGetCaseNoteInformationByIdUseCase.Setup(x => x.Execute(67890)).Returns(caseNoteInformation);
 
             var response = _classUnderTest.GetCaseNote(67890) as OkObjectResult;
 
-            response.StatusCode.Should().Be(200);
-            response.Value.Should().BeEquivalentTo(caseNoteInformation);
+            response?.StatusCode.Should().Be(200);
+            response?.Value.Should().BeEquivalentTo(caseNoteInformation);
         }
 
         [Test]
         public void GetCaseNote_WhenThereIsNoAMatchingCaseNoteId_ReturnsNotFound()
         {
-            CaseNoteInformation caseNoteNotFound = null;
-            _mockGetCaseNoteInformationByIdUseCase.Setup(x => x.Execute(67890)).Returns(caseNoteNotFound);
+            _mockGetCaseNoteInformationByIdUseCase.Setup(x => x.Execute(67890));
 
             var response = _classUnderTest.GetCaseNote(67890) as NotFoundResult;
 
-            response.StatusCode.Should().Be(404);
+            response?.StatusCode.Should().Be(404);
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
@@ -134,7 +134,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
 
             var visitInformation = new List<VisitInformation>
             {
-                TestHelper.CreateDatabaseVisit(visitId).Item1.ToDomain().ToResponse()
+                TestHelper.CreateDatabaseVisit(visitId).ToDomain().ToResponse()
             };
 
             _mockGetVisitInformationByPersonIdUseCase.Setup(x => x.Execute(visitId)).Returns(visitInformation);
@@ -185,7 +185,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
         public void GetResidentRecords_WhenThereAreVisits_ReturnListWithVisitData()
         {
             const long fakerPersonId = 123L;
-            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse().ToSharedResponse(fakerPersonId);
+            var visit = TestHelper.CreateDatabaseVisit().ToDomain().ToResponse().ToSharedResponse(fakerPersonId);
             var residentRecords = new List<ResidentHistoricRecord> { visit };
             _mockGetResidentRecordsUseCase.Setup(x => x.Execute(fakerPersonId)).Returns(residentRecords);
 
@@ -223,7 +223,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
         public void GetResidentRecords_WhenThereAreVisitsAndCaseNotes_ReturnListWithVisitAndCaseNoteData()
         {
             const long fakerPersonId = 123L;
-            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse().ToSharedResponse(fakerPersonId);
+            var visit = TestHelper.CreateDatabaseVisit().ToDomain().ToResponse().ToSharedResponse(fakerPersonId);
             var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse().ToSharedResponse(fakerPersonId);
             var residentRecords = new List<ResidentHistoricRecord> { visit, caseNote };
             _mockGetResidentRecordsUseCase.Setup(x => x.Execute(fakerPersonId)).Returns(residentRecords);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/ResidentsControllerTests.cs
@@ -59,8 +59,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
             var response = _classUnderTest.ViewRecord(12345) as OkObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(200);
-            response.Value.Should().BeEquivalentTo(residentInfo);
+            response?.StatusCode.Should().Be(200);
+            response?.Value.Should().BeEquivalentTo(residentInfo);
         }
 
         [Test]
@@ -92,8 +92,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
             var response = _classUnderTest.ListContacts(rqp, 3, 2) as OkObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(200);
-            response.Value.Should().BeEquivalentTo(residentInformationList);
+            response?.StatusCode.Should().Be(200);
+            response?.Value.Should().BeEquivalentTo(residentInformationList);
         }
 
         [Test]
@@ -106,11 +106,9 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
                 new CaseNoteInformation
                 {
                     MosaicId = "00000",
-                    CaseNoteId = 2222,
+                    CaseNoteId = "2222",
                     CaseNoteTitle = "THIS CASE NOTE HAS A TITLE",
-                    EffectiveDate = fakeTime.ToString("s"),
-                    CreatedOn = fakeTime.ToString("s"),
-                    LastUpdatedOn = fakeTime.ToString("s")
+                    CreatedOn = fakeTime.ToString("s")
                 }
             };
 
@@ -123,8 +121,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
             var response = _classUnderTest.ListCaseNotes(00000) as OkObjectResult;
 
             response.Should().NotBeNull();
-            response.StatusCode.Should().Be(200);
-            response.Value.Should().BeEquivalentTo(caseNoteInformationList);
+            response?.StatusCode.Should().Be(200);
+            response?.Value.Should().BeEquivalentTo(caseNoteInformationList);
         }
 
         [Test]
@@ -160,7 +158,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
 
             var response = _classUnderTest.GetVisitInformation(visitId) as NotFoundResult;
 
-            response.StatusCode.Should().Be(404);
+            response?.StatusCode.Should().Be(404);
         }
 
         [Test]
@@ -246,8 +244,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
 
             var response = _classUnderTest.GetRelationships(getRelationshipsRequest) as BadRequestObjectResult;
 
-            response.StatusCode.Should().Be(400);
-            response.Value.Should().Be("Person ID must be greater than 0");
+            response?.StatusCode.Should().Be(400);
+            response?.Value.Should().Be("Person ID must be greater than 0");
         }
 
         [Test]
@@ -259,8 +257,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
 
             var response = _classUnderTest.GetRelationships(getRelationshipsRequest) as OkObjectResult;
 
-            response.StatusCode.Should().Be(200);
-            response.Value.Should().BeEquivalentTo(relationships);
+            response?.StatusCode.Should().Be(200);
+            response?.Value.Should().BeEquivalentTo(relationships);
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/VisitsControllerTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Controllers/VisitsControllerTests.cs
@@ -28,7 +28,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
         [Test]
         public void GetVisitInformation_WhenThereIsAMatchingVisitId_ReturnsVisitInformation()
         {
-            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse();
+            var visit = TestHelper.CreateDatabaseVisit().ToDomain().ToResponse();
 
             _mockGetVisitInformationByVisitId.Setup(x => x.Execute(visit.VisitId)).Returns(visit);
 
@@ -46,9 +46,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Controllers
         [Test]
         public void GetVisitInformation_WhenThereIsNoAMatchingVisitId_ReturnsNotFound()
         {
-            VisitInformation visitInformation = null;
             const long visitId = 12345L;
-            _mockGetVisitInformationByVisitId.Setup(x => x.Execute(visitId)).Returns(visitInformation);
+            _mockGetVisitInformationByVisitId.Setup(x => x.Execute(visitId));
 
             var response = _classUnderTest.GetVisit(visitId) as NotFoundResult;
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using AutoFixture;
 using ResidentsSocialCarePlatformApi.Tests.V1.Helper;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
-using ResidentsSocialCarePlatformApi.V1.Factories;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 using Address = ResidentsSocialCarePlatformApi.V1.Boundary.Responses.Address;
 
@@ -82,24 +81,12 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
             return new CaseNoteInformation
             {
                 MosaicId = savedCaseNote.PersonId.ToString(),
-                CaseNoteId = savedCaseNote.Id,
+                CaseNoteId = savedCaseNote.Id.ToString(),
                 NoteType = savedNoteType.Description,
                 CaseNoteTitle = savedCaseNote.Title,
-                EffectiveDate = savedCaseNote.EffectiveDate?.ToString("s"),
                 CreatedOn = savedCaseNote.CreatedOn?.ToString("s"),
                 CreatedByName = $"{workerFirstName} {workerLastName}",
-                CreatedByEmail = workerEmailAddress,
-                LastUpdatedOn = savedCaseNote.LastUpdatedOn?.ToString("s"),
-                LastUpdatedName = $"{workerFirstName} {workerLastName}",
-                LastUpdatedEmail = workerEmailAddress,
-                CompletedDate = savedCaseNote.CompletedDate?.ToString("s"),
-                TimeoutDate = savedCaseNote.TimeoutDate?.ToString("s"),
-                CopyOfCaseNoteId = savedCaseNote.CopyOfCaseNoteId,
-                CopiedDate = savedCaseNote.CopiedDate?.ToString("s"),
-                CopiedByName = $"{workerFirstName} {workerLastName}",
-                CopiedByEmail = workerEmailAddress,
-                RootCaseNoteId = savedCaseNote.RootCaseNoteId,
-                PersonVisitId = savedCaseNote.PersonVisitId
+                CreatedByEmail = workerEmailAddress
             };
         }
 
@@ -117,25 +104,13 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
             return new CaseNoteInformation
             {
                 MosaicId = caseNote.PersonId.ToString(),
-                CaseNoteId = caseNote.Id,
+                CaseNoteId = caseNote.Id.ToString(),
                 CaseNoteTitle = caseNote.Title,
-                EffectiveDate = caseNote.EffectiveDate?.ToString("s"),
                 CreatedOn = caseNote.CreatedOn?.ToString("s"),
-                LastUpdatedOn = caseNote.LastUpdatedOn?.ToString("s"),
-                PersonVisitId = caseNote.PersonVisitId,
                 NoteType = noteType.Description,
                 CreatedByName = "Bow Archer",
                 CreatedByEmail = worker.EmailAddress,
-                LastUpdatedName = "Bow Archer",
-                LastUpdatedEmail = worker.EmailAddress,
-                CaseNoteContent = caseNote.Note,
-                RootCaseNoteId = caseNote.RootCaseNoteId,
-                CompletedDate = caseNote.CompletedDate?.ToString("s"),
-                TimeoutDate = caseNote.TimeoutDate?.ToString("s"),
-                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
-                CopiedDate = caseNote.CopiedDate?.ToString("s"),
-                CopiedByName = "Bow Archer",
-                CopiedByEmail = worker.EmailAddress
+                CaseNoteContent = caseNote.Note
             };
         }
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -141,7 +141,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
 
         public static Visit AddVisitToDatabase(SocialCareContext socialCareContext, long? workerId = null)
         {
-            var visitInformation = TestHelper.CreateDatabaseVisit(workerId: workerId).Item1;
+            var visitInformation = TestHelper.CreateDatabaseVisit(workerId: workerId);
             socialCareContext.Visits.Add(visitInformation);
             socialCareContext.SaveChanges();
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -72,7 +72,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
             context.Workers.Add(savedWorker);
 
             var caseNoteId = faker.Create<CaseNote>().Id;
-            var savedCaseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, savedNoteType.Type, savedWorker.SystemUserId, savedWorker.SystemUserId, savedWorker.SystemUserId);
+            var savedCaseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, savedNoteType.Type, savedWorker);
 
 
             context.CaseNotes.Add(savedCaseNote);
@@ -94,7 +94,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
         {
             var noteType = TestHelper.CreateDatabaseNoteType();
             var worker = TestHelper.CreateDatabaseWorker(firstNames: "Bow", lastNames: "Archer");
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, createdBy: worker.SystemUserId, updatedBy: worker.SystemUserId, copiedBy: worker.SystemUserId);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, createdWorker: worker);
 
             socialCareContext.NoteTypes.Add(noteType);
             socialCareContext.Workers.Add(worker);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetCaseNote.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetCaseNote.cs
@@ -33,9 +33,9 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
             var nonExistentCaseNoteId = "1234";
             var uri = new Uri($"api/v1/case-notes/{nonExistentCaseNoteId}", UriKind.Relative);
 
-            var response = Client.GetAsync(uri);
+            var response = await Client.GetAsync(uri);
 
-            response.Result.StatusCode.Should().Be(404);
+            response.StatusCode.Should().Be(404);
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByPersonIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByPersonIdTests.cs
@@ -16,7 +16,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
         public async Task WhenThereIsAVisitWithMatchingPersonId_Returns200AndVisitInformation()
         {
             var worker = E2ETestHelpers.AddWorkerToDatabase(SocialCareContext);
-            var visitInformation = E2ETestHelpers.AddVisitToDatabase(SocialCareContext, worker.Id).ToDomain().ToResponse();
+            var visitInformation = E2ETestHelpers.AddVisitToDatabase(SocialCareContext, worker.Id, worker).ToDomain().ToResponse();
             visitInformation.CreatedByEmail = worker.EmailAddress;
             visitInformation.CreatedByName = $"{worker.FirstNames} {worker.LastNames}";
             var uri = new Uri($"api/v1/residents/{visitInformation.PersonId}/visits", UriKind.Relative);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByVisitIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByVisitIdTests.cs
@@ -15,7 +15,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
         public async Task WhenThereIsAVisitId_Returns200AndVisitInformation()
         {
             var worker = E2ETestHelpers.AddWorkerToDatabase(SocialCareContext);
-            var visit = E2ETestHelpers.AddVisitToDatabase(SocialCareContext, worker.Id).ToDomain().ToResponse();
+            var visit = E2ETestHelpers.AddVisitToDatabase(SocialCareContext, worker.Id, worker).ToDomain().ToResponse();
             visit.CreatedByEmail = worker.EmailAddress;
             visit.CreatedByName = $"{worker.FirstNames} {worker.LastNames}";
             var uri = new Uri($"api/v1/visits/{visit.VisitId}", UriKind.Relative);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/ListCaseNotesForAPerson.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/ListCaseNotesForAPerson.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Threading.Tasks;
-using AutoFixture;
 using FluentAssertions;
 using Newtonsoft.Json;
 using NUnit.Framework;
@@ -11,18 +10,9 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
     [TestFixture]
     public class ListCaseNotesForAPerson : EndToEndTests<Startup>
     {
-        private IFixture _fixture;
-
-        [SetUp]
-        public void SetUp()
-        {
-            _fixture = new Fixture();
-        }
-
         [Test]
         public async Task ReturnsAllCaseNotesForASpecificPerson()
         {
-
             var person = E2ETestHelpers.AddPersonToDatabase(SocialCareContext);
 
             var expectedCaseNoteResponseOne = E2ETestHelpers.AddCaseNoteForASpecificPersonToDb(SocialCareContext, person.Id);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -124,46 +124,22 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                     MosaicId = "12345",
                     CaseNoteId = 67890,
                     CaseNoteTitle = "I AM A CASE NOTE",
-                    EffectiveDate = recordOneTime,
                     CreatedOn = recordOneTime,
-                    LastUpdatedOn = recordOneTime,
-                    PersonVisitId = 456,
                     NoteType = "Case Summary (ASC)",
                     CaseNoteContent = "",
                     CreatedByName = "Catra Grayskull",
-                    CreatedByEmail = "catra@grayskull.com",
-                    LastUpdatedName = "Catra Grayskull",
-                    LastUpdatedEmail = "catra@grayskull.com",
-                    RootCaseNoteId = 789,
-                    CompletedDate = recordOneTime,
-                    TimeoutDate = recordOneTime,
-                    CopyOfCaseNoteId = 567,
-                    CopiedDate = recordOneTime,
-                    CopiedByName = "Catra Grayskull",
-                    CopiedByEmail = "catra@grayskull.com"
+                    CreatedByEmail = "catra@grayskull.com"
                 },
                 new CaseNoteInformation
                 {
                     MosaicId = "12345",
                     CaseNoteId = 100000,
                     CaseNoteTitle = "I AM ANOTHER CASE NOTE",
-                    EffectiveDate = recordTwoTime,
                     CreatedOn = recordTwoTime,
-                    LastUpdatedOn = recordTwoTime,
-                    PersonVisitId = 123,
                     NoteType = "Case Summary (ASC)",
                     CaseNoteContent = "",
                     CreatedByName = "A Name goes here",
                     CreatedByEmail = "some@email.com",
-                    LastUpdatedName = "A Name goes here",
-                    LastUpdatedEmail = "some@email.com",
-                    RootCaseNoteId = 456,
-                    CompletedDate = recordTwoTime,
-                    TimeoutDate = recordTwoTime,
-                    CopyOfCaseNoteId = 789,
-                    CopiedDate = recordTwoTime,
-                    CopiedByName = "This was copied",
-                    CopiedByEmail = "copied@copy.com"
                 }
             };
 
@@ -172,48 +148,24 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                 new CaseNoteInformationResponse
                 {
                     MosaicId = "12345",
-                    CaseNoteId = 67890,
+                    CaseNoteId = "67890",
                     CaseNoteTitle = "I AM A CASE NOTE",
-                    EffectiveDate = formattedRecordOneTime,
                     CreatedOn = formattedRecordOneTime,
-                    LastUpdatedOn = formattedRecordOneTime,
-                    PersonVisitId = 456,
                     NoteType = "Case Summary (ASC)",
                     CaseNoteContent = "",
                     CreatedByName = "Catra Grayskull",
-                    CreatedByEmail = "catra@grayskull.com",
-                    LastUpdatedName = "Catra Grayskull",
-                    LastUpdatedEmail = "catra@grayskull.com",
-                    RootCaseNoteId = 789,
-                    CompletedDate = formattedRecordOneTime,
-                    TimeoutDate = formattedRecordOneTime,
-                    CopyOfCaseNoteId = 567,
-                    CopiedDate = formattedRecordOneTime,
-                    CopiedByName = "Catra Grayskull",
-                    CopiedByEmail = "catra@grayskull.com"
+                    CreatedByEmail = "catra@grayskull.com"
                 },
                 new CaseNoteInformationResponse
                 {
                     MosaicId = "12345",
-                    CaseNoteId = 100000,
+                    CaseNoteId = "100000",
                     CaseNoteTitle = "I AM ANOTHER CASE NOTE",
-                    EffectiveDate = formattedRecordTwoTime,
                     CreatedOn = formattedRecordTwoTime,
-                    LastUpdatedOn = formattedRecordTwoTime,
-                    PersonVisitId = 123,
                     NoteType = "Case Summary (ASC)",
                     CaseNoteContent = "",
                     CreatedByName = "A Name goes here",
                     CreatedByEmail = "some@email.com",
-                    LastUpdatedName = "A Name goes here",
-                    LastUpdatedEmail = "some@email.com",
-                    RootCaseNoteId = 456,
-                    CompletedDate = formattedRecordTwoTime,
-                    TimeoutDate = formattedRecordTwoTime,
-                    CopyOfCaseNoteId = 789,
-                    CopiedDate = formattedRecordTwoTime,
-                    CopiedByName = "This was copied",
-                    CopiedByEmail = "copied@copy.com"
                 }
             };
 
@@ -231,103 +183,26 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                 MosaicId = "12345",
                 CaseNoteId = 67890,
                 CaseNoteTitle = "I AM A CASE NOTE",
-                EffectiveDate = dateTime,
                 CreatedOn = dateTime,
-                LastUpdatedOn = dateTime,
-                PersonVisitId = 456,
                 NoteType = "Case Summary (ASC)",
                 CreatedByName = "Catra Grayskull",
                 CreatedByEmail = "catra@grayskull.com",
-                LastUpdatedName = "Catra Grayskull",
-                LastUpdatedEmail = "catra@grayskull.com",
-                CaseNoteContent = "I am case note content.",
-                RootCaseNoteId = 789,
-                CompletedDate = dateTime,
-                TimeoutDate = dateTime,
-                CopyOfCaseNoteId = 567,
-                CopiedDate = dateTime,
-                CopiedByName = "Catra Grayskull",
-                CopiedByEmail = "catra@grayskull.com"
+                CaseNoteContent = "I am case note content."
             };
 
             var expectedResponse = new CaseNoteInformationResponse
             {
                 MosaicId = "12345",
-                CaseNoteId = 67890,
+                CaseNoteId = "67890",
                 CaseNoteTitle = "I AM A CASE NOTE",
-                EffectiveDate = formattedDateTime,
                 CreatedOn = formattedDateTime,
-                LastUpdatedOn = formattedDateTime,
-                PersonVisitId = 456,
                 NoteType = "Case Summary (ASC)",
                 CreatedByName = "Catra Grayskull",
                 CreatedByEmail = "catra@grayskull.com",
-                LastUpdatedName = "Catra Grayskull",
-                LastUpdatedEmail = "catra@grayskull.com",
-                CaseNoteContent = "I am case note content.",
-                RootCaseNoteId = 789,
-                CompletedDate = formattedDateTime,
-                TimeoutDate = formattedDateTime,
-                CopyOfCaseNoteId = 567,
-                CopiedDate = formattedDateTime,
-                CopiedByName = "Catra Grayskull",
-                CopiedByEmail = "catra@grayskull.com"
+                CaseNoteContent = "I am case note content."
             };
 
             domain.ToResponse().Should().BeEquivalentTo(expectedResponse);
-        }
-
-        [Test]
-        public void CanMapVisitInformationToSharedToResidentHistoricRecordVisit()
-        {
-            var person = TestHelper.CreateDatabasePersonEntity();
-            var visit = TestHelper.CreateDatabaseVisit().ToDomain().ToResponse();
-
-            var residentHistoricRecordVisit = new ResidentHistoricRecordVisit
-            {
-                RecordId = visit.VisitId,
-                FormName = "",
-                PersonId = person.Id,
-                FirstName = "",
-                LastName = "",
-                DateOfBirth = "",
-                OfficerEmail = visit.CreatedByEmail,
-                CaseFormUrl = "",
-                CaseFormTimeStamp = "",
-                DateOfEvent = visit.ActualDateTime ?? visit.PlannedDateTime,
-                CaseNoteTitle = "",
-                RecordType = RecordType.Visit,
-                Visit = visit,
-                IsHistoric = true
-            };
-
-            visit.ToSharedResponse(person.Id).Should().BeEquivalentTo(residentHistoricRecordVisit);
-        }
-
-        [Test]
-        public void CanMapCaseNoteInformationToSharedToResidentHistoricRecordCaseNote()
-        {
-            var person = TestHelper.CreateDatabasePersonEntity();
-            var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse();
-
-            var residentHistoricRecordCaseNote = new ResidentHistoricRecordCaseNote
-            {
-                RecordId = caseNote.CaseNoteId,
-                FormName = "",
-                PersonId = person.Id,
-                FirstName = "",
-                LastName = "",
-                DateOfBirth = "",
-                OfficerEmail = caseNote.CopiedByEmail,
-                CaseFormUrl = "",
-                CaseFormTimeStamp = "",
-                DateOfEvent = caseNote.CompletedDate,
-                CaseNoteTitle = caseNote.CaseNoteTitle,
-                RecordType = RecordType.Visit,
-                CaseNote = caseNote
-            };
-
-            caseNote.ToSharedResponse(person.Id).Should().BeEquivalentTo(caseNote.ToSharedResponse(person.Id));
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactoryTests.cs
@@ -281,7 +281,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
         public void CanMapVisitInformationToSharedToResidentHistoricRecordVisit()
         {
             var person = TestHelper.CreateDatabasePersonEntity();
-            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse();
+            var visit = TestHelper.CreateDatabaseVisit().ToDomain().ToResponse();
 
             var residentHistoricRecordVisit = new ResidentHistoricRecordVisit
             {
@@ -297,7 +297,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories
                 DateOfEvent = visit.ActualDateTime ?? visit.PlannedDateTime,
                 CaseNoteTitle = "",
                 RecordType = RecordType.Visit,
-                Visit = visit
+                Visit = visit,
+                IsHistoric = true
             };
 
             visit.ToSharedResponse(person.Id).Should().BeEquivalentTo(residentHistoricRecordVisit);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
@@ -102,7 +102,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             var noteType = TestHelper.CreateDatabaseNoteType();
             var worker = TestHelper.CreateDatabaseWorker(systemUserId: "existingUser");
             var updatedByWorker = TestHelper.CreateDatabaseWorker();
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, createdBy: "nonExistingUser");
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type);
             SocialCareContext.NoteTypes.Add(noteType);
             SocialCareContext.Workers.Add(worker);
             SocialCareContext.Workers.Add(updatedByWorker);
@@ -119,7 +119,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         {
             var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);
             var worker = TestHelper.CreateDatabaseWorker(workerFirstNames, workerLastNames, workerEmailAddress, workerSystemUserId);
-            var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type, copiedBy, worker.SystemUserId, worker.SystemUserId);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type, worker);
 
             SocialCareContext.NoteTypes.Add(noteType);
             SocialCareContext.Workers.Add(worker);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
@@ -4,7 +4,7 @@ using ResidentsSocialCarePlatformApi.V1.Gateways;
 using ResidentsSocialCarePlatformApi.Tests.V1.Helper;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 
-namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
+namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
 {
     [NonParallelizable]
     [TestFixture]
@@ -38,7 +38,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
 
             var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
 
-            response.CaseNoteId.Should().Be(caseNote.Id);
+            response?.CaseNoteId.Should().Be(caseNote.Id);
         }
 
         [Test]
@@ -48,19 +48,11 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
 
             var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
 
-            response.MosaicId.Should().Be(caseNote.PersonId.ToString());
-            response.CaseNoteId.Should().Be(caseNote.Id);
-            response.PersonVisitId.Should().Be(caseNote.PersonVisitId);
-            response.CaseNoteTitle.Should().Be(caseNote.Title);
-            response.EffectiveDate.Should().Be(caseNote.EffectiveDate);
-            response.CreatedOn.Should().Be(caseNote.CreatedOn);
-            response.LastUpdatedOn.Should().Be(caseNote.LastUpdatedOn);
-            response.CaseNoteContent.Should().Be(caseNote.Note);
-            response.RootCaseNoteId.Should().Be(caseNote.RootCaseNoteId);
-            response.CompletedDate.Should().Be(caseNote.CompletedDate);
-            response.TimeoutDate.Should().Be(caseNote.TimeoutDate);
-            response.CopyOfCaseNoteId.Should().Be(caseNote.CopyOfCaseNoteId);
-            response.CopiedDate.Should().Be(caseNote.CopiedDate);
+            response?.MosaicId.Should().Be(caseNote.PersonId.ToString());
+            response?.CaseNoteId.Should().Be(caseNote.Id);
+            response?.CaseNoteTitle.Should().Be(caseNote.Title);
+            response?.CreatedOn.Should().Be(caseNote.CreatedOn);
+            response?.CaseNoteContent.Should().Be(caseNote.Note);
         }
 
         [Test]
@@ -72,7 +64,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
 
             var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
 
-            response.NoteType.Should().Be(noteTypeDescription);
+            response?.NoteType.Should().Be(noteTypeDescription);
         }
 
         [Test]
@@ -83,12 +75,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
 
             var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
 
-            response.CreatedByName.Should().Be("Adora Grayskull");
-            response.CreatedByEmail.Should().Be(workerEmailAddress);
-            response.LastUpdatedName.Should().Be("Adora Grayskull");
-            response.LastUpdatedEmail.Should().Be(workerEmailAddress);
-            response.CopiedByName.Should().Be("Adora Grayskull");
-            response.CopiedByEmail.Should().Be(workerEmailAddress);
+            response?.CreatedByName.Should().Be("Adora Grayskull");
+            response?.CreatedByEmail.Should().Be(workerEmailAddress);
         }
 
         [Test]
@@ -105,24 +93,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
 
             var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
 
-            response.NoteType.Should().BeNull();
-        }
-
-        [Test]
-        public void WhenCopiedByIsNull_ReturnsNullForCopiedByNameAndCopiedByEmail()
-        {
-            var noteType = TestHelper.CreateDatabaseNoteType();
-            var worker = TestHelper.CreateDatabaseWorker();
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, copiedBy: null);
-            SocialCareContext.NoteTypes.Add(noteType);
-            SocialCareContext.Workers.Add(worker);
-            SocialCareContext.CaseNotes.Add(caseNote);
-            SocialCareContext.SaveChanges();
-
-            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
-
-            response.CopiedByName.Should().BeNull();
-            response.CopiedByEmail.Should().BeNull();
+            response?.NoteType.Should().BeNull();
         }
 
         [Test]
@@ -140,27 +111,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways
 
             var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
 
-            response.CreatedByEmail.Should().BeNull();
-            response.CreatedByName.Should().BeNull();
-        }
-
-        [Test]
-        public void WhenUpdatedByWorkerIsNull_ReturnsNullForUpdatedByNameAndEmail()
-        {
-            var noteType = TestHelper.CreateDatabaseNoteType();
-            var worker = TestHelper.CreateDatabaseWorker(systemUserId: "existingUser");
-            var createdByWorker = TestHelper.CreateDatabaseWorker();
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, updatedBy: "nonExistingUser");
-            SocialCareContext.NoteTypes.Add(noteType);
-            SocialCareContext.Workers.Add(worker);
-            SocialCareContext.Workers.Add(createdByWorker);
-            SocialCareContext.CaseNotes.Add(caseNote);
-            SocialCareContext.SaveChanges();
-
-            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
-
-            response.LastUpdatedEmail.Should().BeNull();
-            response.LastUpdatedName.Should().BeNull();
+            response?.CreatedByEmail.Should().BeNull();
+            response?.CreatedByName.Should().BeNull();
         }
 
         private CaseNote AddCaseNoteWithNoteTypeAndWorkerToDatabase(long id = 123, long personId = 123, string caseNoteType = "CASSUMASC", string caseNoteTypeDescription = "Case Summary (ASC)", string copiedBy = "CGYORFI", string workerFirstNames = "Csaba", string workerLastNames = "Gyorfi", string workerEmailAddress = "cgyorfi@email.com", string workerSystemUserId = "CGYORFI")

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
@@ -33,8 +33,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         [Test]
         public void WhenThereAreMultipleCaseNotes_ReturnsCaseNoteWithMatchingId()
         {
-            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase(id: 123);
-            AddCaseNoteWithNoteTypeAndWorkerToDatabase(id: 456, caseNoteType: "DIFF", caseNoteTypeDescription: "Different");
+            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase(id: 32352353);
+            AddCaseNoteWithNoteTypeAndWorkerToDatabase(id: 3253253325, caseNoteType: "DIFF", caseNoteTypeDescription: "Different");
 
             var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
 
@@ -70,13 +70,12 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         [Test]
         public void WhenThereIsAMatchingRecord_ReturnsDetailsFromWorkers()
         {
-            const string workerEmailAddress = "adora@grayskull.com";
-            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase(copiedBy: "AGRAYSKULL", workerFirstNames: "Adora", workerLastNames: "Grayskull", workerEmailAddress: workerEmailAddress, workerSystemUserId: "AGRAYSKULL");
+            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase();
 
             var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
 
-            response?.CreatedByName.Should().Be("Adora Grayskull");
-            response?.CreatedByEmail.Should().Be(workerEmailAddress);
+            response?.CreatedByName.Should().Be($"{caseNote.Worker.FirstNames} {caseNote.Worker.LastNames}");
+            response?.CreatedByEmail.Should().Be(caseNote.Worker.EmailAddress);
         }
 
         [Test]
@@ -96,29 +95,10 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             response?.NoteType.Should().BeNull();
         }
 
-        [Test]
-        public void WhenCreatedByWorkerIsNull_ReturnsNullForCreatedByNameAndEmail()
-        {
-            var noteType = TestHelper.CreateDatabaseNoteType();
-            var worker = TestHelper.CreateDatabaseWorker(systemUserId: "existingUser");
-            var updatedByWorker = TestHelper.CreateDatabaseWorker();
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type);
-            SocialCareContext.NoteTypes.Add(noteType);
-            SocialCareContext.Workers.Add(worker);
-            SocialCareContext.Workers.Add(updatedByWorker);
-            SocialCareContext.CaseNotes.Add(caseNote);
-            SocialCareContext.SaveChanges();
-
-            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
-
-            response?.CreatedByEmail.Should().BeNull();
-            response?.CreatedByName.Should().BeNull();
-        }
-
         private CaseNote AddCaseNoteWithNoteTypeAndWorkerToDatabase(long id = 123, long personId = 123, string caseNoteType = "CASSUMASC", string caseNoteTypeDescription = "Case Summary (ASC)", string copiedBy = "CGYORFI", string workerFirstNames = "Csaba", string workerLastNames = "Gyorfi", string workerEmailAddress = "cgyorfi@email.com", string workerSystemUserId = "CGYORFI")
         {
             var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);
-            var worker = TestHelper.CreateDatabaseWorker(workerFirstNames, workerLastNames, workerEmailAddress, workerSystemUserId);
+            var worker = TestHelper.CreateDatabaseWorker();
             var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type, worker);
 
             SocialCareContext.NoteTypes.Add(noteType);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
@@ -101,11 +101,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);
             SocialCareContext.NoteTypes.Add(noteType);
 
-            var workerFirstNames = faker.Create<Worker>().FirstNames;
-            var workerLastNames = faker.Create<Worker>().LastNames;
-            var workerEmailAddress = faker.Create<Worker>().EmailAddress;
             var workerSystemUserId = faker.Create<string>().Substring(0, 10);
-            var worker = TestHelper.CreateDatabaseWorker(workerFirstNames, workerLastNames, workerEmailAddress, workerSystemUserId);
+            var worker = TestHelper.CreateDatabaseWorker(systemUserId: workerSystemUserId);
             SocialCareContext.Workers.Add(worker);
 
             var caseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, noteType.Type, worker);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
@@ -108,7 +108,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             var worker = TestHelper.CreateDatabaseWorker(workerFirstNames, workerLastNames, workerEmailAddress, workerSystemUserId);
             SocialCareContext.Workers.Add(worker);
 
-            var caseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, noteType.Type, workerSystemUserId, workerSystemUserId, workerSystemUserId);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, noteType.Type, worker);
             SocialCareContext.CaseNotes.Add(caseNote);
 
             SocialCareContext.SaveChanges();

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
@@ -101,8 +101,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);
             SocialCareContext.NoteTypes.Add(noteType);
 
-            var workerSystemUserId = faker.Create<string>().Substring(0, 10);
-            var worker = TestHelper.CreateDatabaseWorker(systemUserId: workerSystemUserId);
+            var worker = TestHelper.CreateDatabaseWorker();
             SocialCareContext.Workers.Add(worker);
 
             var caseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, noteType.Type, worker);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
@@ -36,7 +36,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             var response = _classUnderTest.GetAllCaseNotes(person.Id);
 
             response.Count.Should().Be(1);
-            response.FirstOrDefault().CaseNoteId.Should().Be(caseNote.Id);
+            response.FirstOrDefault()?.CaseNoteId.Should().Be(caseNote.Id);
         }
 
         [Test]
@@ -63,21 +63,9 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
                 CaseNoteId = caseNote.Id,
                 NoteType = noteType.Description,
                 CaseNoteTitle = caseNote.Title,
-                EffectiveDate = caseNote.EffectiveDate,
                 CreatedOn = caseNote.CreatedOn,
                 CreatedByName = $"{caseWorker.FirstNames} {caseWorker.LastNames}",
-                CreatedByEmail = caseWorker.EmailAddress,
-                LastUpdatedOn = caseNote.LastUpdatedOn,
-                LastUpdatedName = $"{caseWorker.FirstNames} {caseWorker.LastNames}",
-                LastUpdatedEmail = caseWorker.EmailAddress,
-                CompletedDate = caseNote.CompletedDate,
-                TimeoutDate = caseNote.TimeoutDate,
-                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
-                CopiedDate = caseNote.CopiedDate,
-                CopiedByName = $"{caseWorker.FirstNames} {caseWorker.LastNames}",
-                CopiedByEmail = caseWorker.EmailAddress,
-                RootCaseNoteId = caseNote.RootCaseNoteId,
-                PersonVisitId = caseNote.PersonVisitId
+                CreatedByEmail = caseWorker.EmailAddress
             };
 
             var response = _classUnderTest.GetAllCaseNotes(person.Id);
@@ -93,7 +81,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
 
             var response = _classUnderTest.GetAllCaseNotes(person.Id);
 
-            response.FirstOrDefault().CaseNoteContent.Should().BeNullOrEmpty();
+            response.FirstOrDefault()?.CaseNoteContent.Should().BeNullOrEmpty();
         }
 
         private Person AddPersonToDatabase()

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetVisitInformationByPersonIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetVisitInformationByPersonIdTests.cs
@@ -35,7 +35,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         [Test]
         public void WhenThereIsOneMatch_ReturnsAListContainingTheMatchingVisit()
         {
-            var visit = AddVisitToDatabase().Item1;
+            var visit = AddVisitToDatabase();
 
             var response = _classUnderTest.GetVisitInformationByPersonId(visit.PersonId);
 
@@ -77,7 +77,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         [Test]
         public void WhenThereIsAMatchingRecord_ReturnsDetailsFromVisit()
         {
-            var (visit, worker) = AddVisitToDatabase();
+            var visit = AddVisitToDatabase();
 
             var response = _classUnderTest.GetVisitInformationByPersonId(visit.PersonId).First();
 
@@ -97,19 +97,19 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             response.CpVisitScheduleStepId.Should().Be(visit.CpVisitScheduleStepId);
             response.CpVisitScheduleDays.Should().Be(visit.CpVisitScheduleDays);
             response.CpVisitOnTime.Should().Be(visit.CpVisitOnTime);
-            response.CreatedByEmail.Should().Be(worker.EmailAddress);
-            response.CreatedByName.Should().Be($"{worker.FirstNames} {worker.LastNames}");
+            response.CreatedByEmail.Should().Be(visit.Worker.EmailAddress);
+            response.CreatedByName.Should().Be($"{visit.Worker.FirstNames} {visit.Worker.LastNames}");
         }
 
-        private (Visit, Worker) AddVisitToDatabase(long? visitId = null, long? workerId = null, long? personId = null)
+        private Visit AddVisitToDatabase(long? visitId = null, long? workerId = null, long? personId = null)
         {
-            var (visit, worker) = TestHelper.CreateDatabaseVisit(visitId, personId, workerId: workerId);
+            var visit= TestHelper.CreateDatabaseVisit(visitId, personId, workerId: workerId);
 
             SocialCareContext.Visits.Add(visit);
-            SocialCareContext.Workers.Add(worker);
+            SocialCareContext.Workers.Add(visit.Worker);
             SocialCareContext.SaveChanges();
 
-            return (visit, worker);
+            return visit;
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetVisitInformationByPersonIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetVisitInformationByPersonIdTests.cs
@@ -103,7 +103,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
 
         private Visit AddVisitToDatabase(long? visitId = null, long? workerId = null, long? personId = null)
         {
-            var visit= TestHelper.CreateDatabaseVisit(visitId, personId, workerId: workerId);
+            var visit = TestHelper.CreateDatabaseVisit(visitId, personId, workerId: workerId);
 
             SocialCareContext.Visits.Add(visit);
             SocialCareContext.Workers.Add(visit.Worker);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetVisitInformationByVisitIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetVisitInformationByVisitIdTests.cs
@@ -36,7 +36,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         [Test]
         public void WhenThereAreMultipleVisits_ReturnsVisitsWithMatchingId()
         {
-            var visit = AddVisitToDatabase().Item1;
+            var visit = AddVisitToDatabase();
             AddVisitToDatabase();
 
             var response = _classUnderTest.GetVisitInformationByVisitId(visit.VisitId);
@@ -52,7 +52,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         [Test]
         public void WhenThereIsAMatchingVisit_ReturnsVisitDetails()
         {
-            var (visit, worker) = AddVisitToDatabase();
+            var visit = AddVisitToDatabase();
 
             var response = _classUnderTest.GetVisitInformationByVisitId(visit.VisitId);
 
@@ -74,19 +74,19 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             response.CpVisitScheduleStepId.Should().Be(visit.CpVisitScheduleStepId);
             response.CpVisitScheduleDays.Should().Be(visit.CpVisitScheduleDays);
             response.CpVisitOnTime.Should().Be(visit.CpVisitOnTime);
-            response.CreatedByEmail.Should().Be(worker.EmailAddress);
-            response.CreatedByName.Should().Be($"{worker.FirstNames} {worker.LastNames}");
+            response.CreatedByEmail.Should().Be(visit.Worker.EmailAddress);
+            response.CreatedByName.Should().Be($"{visit.Worker.FirstNames} {visit.Worker.LastNames}");
         }
 
-        private (Visit, Worker) AddVisitToDatabase(long? visitId = null, long? workerId = null)
+        private Visit AddVisitToDatabase(long? visitId = null, long? workerId = null)
         {
-            var (visit, worker) = TestHelper.CreateDatabaseVisit(visitId, workerId: workerId);
+            var visit = TestHelper.CreateDatabaseVisit(visitId, workerId: workerId);
 
             SocialCareContext.Visits.Add(visit);
-            SocialCareContext.Workers.Add(worker);
+            SocialCareContext.Workers.Add(visit.Worker);
             SocialCareContext.SaveChanges();
 
-            return (visit, worker);
+            return visit;
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using AutoFixture;
 using Bogus;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
-using static System.Int32;
 using Address = ResidentsSocialCarePlatformApi.V1.Infrastructure.Address;
 using Person = ResidentsSocialCarePlatformApi.V1.Infrastructure.Person;
 using ResidentsSocialCarePlatformApi.V1.Domain;
@@ -23,7 +22,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .RuleFor(person => person.LastName, f => lastname ?? f.Name.LastName())
                 .RuleFor(person => person.FullName, f => f.Name.FullName())
                 .RuleFor(person => person.DateOfBirth, f => f.Date.Past(50, DateTime.Now).Date)
-                .RuleFor(person => person.NhsNumber, f => f.Random.Number(MaxValue))
+                .RuleFor(person => person.NhsNumber, f => f.Random.Number(int.MaxValue))
                 .RuleFor(person => person.Gender, f => f.Person.Gender.ToString()[0].ToString())
                 .RuleFor(person => person.EmailAddress, f => f.Person.Email)
                 .RuleFor(person => person.Restricted, f => f.Random.String2(1, "YN"))
@@ -67,21 +66,17 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
         }
 
         public static CaseNote CreateDatabaseCaseNote(long id = 123, long personId = 123, string noteType = "CASSUMASC",
-            string copiedBy = "CGYORFI", string createdBy = "CGYORFI", string updatedBy = "CGYORFI", Worker? createdWorker = null)
+            string copiedBy = "CGYORFI", string updatedBy = "CGYORFI", Worker? createdWorker = null)
         {
-            var faker = new Fixture();
-
             createdWorker ??= CreateDatabaseWorker();
 
-            return faker.Build<CaseNote>()
-                .With(caseNote => caseNote.Id, id)
-                .With(caseNote => caseNote.PersonId, personId)
-                .With(caseNote => caseNote.NoteType, noteType)
-                .With(caseNote => caseNote.CreatedBy, createdBy)
-                .With(caseNote => caseNote.LastUpdatedBy, updatedBy)
-                .With(caseNote => caseNote.CopiedBy, copiedBy)
-                .With(caseNote => caseNote.CreatedByWorker, createdWorker)
-                .Create();
+            return new Faker<CaseNote>()
+                .RuleFor(caseNote => caseNote.Id, id)
+                .RuleFor(caseNote => caseNote.PersonId, personId)
+                .RuleFor(caseNote => caseNote.NoteType, noteType)
+                .RuleFor(caseNote => caseNote.LastUpdatedBy, updatedBy)
+                .RuleFor(caseNote => caseNote.CopiedBy, copiedBy)
+                .RuleFor(caseNote => caseNote.CreatedByWorker, createdWorker);
         }
 
         public static NoteType CreateDatabaseNoteType(string noteType = "CASSUMASC", string description = "Case Summary (ASC)")

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -66,7 +66,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
         }
 
         public static CaseNote CreateDatabaseCaseNote(long id = 123, long personId = 123, string noteType = "CASSUMASC",
-            string copiedBy = "CGYORFI", string updatedBy = "CGYORFI", Worker? createdWorker = null)
+            Worker? createdWorker = null)
         {
             createdWorker ??= CreateDatabaseWorker();
 
@@ -74,9 +74,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .RuleFor(caseNote => caseNote.Id, id)
                 .RuleFor(caseNote => caseNote.PersonId, personId)
                 .RuleFor(caseNote => caseNote.NoteType, noteType)
-                .RuleFor(caseNote => caseNote.LastUpdatedBy, updatedBy)
-                .RuleFor(caseNote => caseNote.CopiedBy, copiedBy)
-                .RuleFor(caseNote => caseNote.CreatedByWorker, createdWorker);
+                .RuleFor(caseNote => caseNote.CreatedBy, createdWorker.SystemUserId)
+                .RuleFor(caseNote => caseNote.Worker, createdWorker);
         }
 
         public static NoteType CreateDatabaseNoteType(string noteType = "CASSUMASC", string description = "Case Summary (ASC)")

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -101,7 +101,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .RuleFor(worker => worker.SystemUserId, systemUserId);
         }
 
-        public static (Visit, Worker) CreateDatabaseVisit(
+        public static Visit CreateDatabaseVisit(
             long? visitId = null,
             long? personId = null,
             long? orgId = null,
@@ -126,9 +126,10 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .RuleFor(v => v.CpRegistrationId, f => cpRegistrationId ?? f.UniqueIndex)
                 .RuleFor(v => v.CpVisitScheduleStepId, f => cpVisitScheduleStepId ?? f.UniqueIndex)
                 .RuleFor(v => v.CpVisitScheduleDays, f => f.Random.Number(999))
-                .RuleFor(v => v.CpVisitOnTime, f => f.Random.String2(1, "YN"));
+                .RuleFor(v => v.CpVisitOnTime, f => f.Random.String2(1, "YN"))
+                .RuleFor(v => v.Worker, worker);
 
-            return (visit, worker);
+            return visit;
         }
 
         public static Organisation CreateDatabaseOrganisation(

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -32,7 +32,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .RuleFor(person => person.Nationality, f => f.Random.String2(1, 20));
         }
 
-        public static Address CreateDatabaseAddressForPersonId(long personId, string postcode = null, string address = null)
+        public static Address CreateDatabaseAddressForPersonId(long personId, string? postcode = null, string? address = null)
         {
             var faker = new Fixture();
 
@@ -67,12 +67,11 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
         }
 
         public static CaseNote CreateDatabaseCaseNote(long id = 123, long personId = 123, string noteType = "CASSUMASC",
-            string copiedBy = "CGYORFI", string createdBy = "CGYORFI", string updatedBy = "CGYORFI", Worker? createdWorker = null,
-            Worker? updatedWorker = null, Worker? copiedWorker = null)
+            string copiedBy = "CGYORFI", string createdBy = "CGYORFI", string updatedBy = "CGYORFI", Worker? createdWorker = null)
         {
             var faker = new Fixture();
 
-            createdWorker ??= TestHelper.CreateDatabaseWorker();
+            createdWorker ??= CreateDatabaseWorker();
 
             return faker.Build<CaseNote>()
                 .With(caseNote => caseNote.Id, id)
@@ -90,8 +89,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
             var faker = new Fixture();
 
             return faker.Build<NoteType>()
-                .With(noteType => noteType.Type, noteType)
-                .With(noteType => noteType.Description, description)
+                .With(n => n.Type, noteType)
+                .With(n => n.Description, description)
                 .Create();
         }
 
@@ -119,8 +118,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .RuleFor(v => v.VisitId, f => visitId ?? f.UniqueIndex)
                 .RuleFor(v => v.PersonId, f => personId ?? f.UniqueIndex)
                 .RuleFor(v => v.VisitType, f => f.Random.String2(1, 20))
-                .RuleFor(v => v.PlannedDateTime, f => f.Date.Past(1))
-                .RuleFor(v => v.ActualDateTime, f => f.Date.Past(1))
+                .RuleFor(v => v.PlannedDateTime, f => f.Date.Past())
+                .RuleFor(v => v.ActualDateTime, f => f.Date.Past())
                 .RuleFor(v => v.ReasonNotPlanned, f => f.Random.String2(1, 16))
                 .RuleFor(v => v.ReasonVisitNotMade, f => f.Random.String2(1, 16))
                 .RuleFor(v => v.SeenAloneFlag, f => f.Random.String2(1, "YN"))
@@ -169,7 +168,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .RuleFor(personalRelationship => personalRelationship.PersonalRelTypeId, f => personalRelTypeId ?? f.UniqueIndex)
                 .RuleFor(personalRelationship => personalRelationship.OtherPersonId, f => otherPersonId ?? f.UniqueIndex)
                 .RuleFor(personalRelationship => personalRelationship.StartDate, f => f.Date.Past(3))
-                .RuleFor(personalRelationship => personalRelationship.EndDate, f => f.Date.Past(1))
+                .RuleFor(personalRelationship => personalRelationship.EndDate, f => f.Date.Past())
                 .RuleFor(personalRelationship => personalRelationship.FamilyCategory, f => f.Random.String2(1, 255))
                 .RuleFor(personalRelationship => personalRelationship.IsMother, f => f.Random.String2(1, "YN"))
                 .RuleFor(personalRelationship => personalRelationship.ParentalReponsibility, f => f.Random.String2(1, "YN"))

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -88,14 +88,14 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .Create();
         }
 
-        public static Worker CreateDatabaseWorker(string firstNames = "Csaba", string lastNames = "Gyorfi", string emailAddress = "cgyorfi@email.com", string systemUserId = "CGYORFI")
+        public static Worker CreateDatabaseWorker()
         {
             return new Faker<Worker>()
                 .RuleFor(worker => worker.Id, f => f.UniqueIndex)
-                .RuleFor(worker => worker.FirstNames, firstNames)
-                .RuleFor(worker => worker.LastNames, lastNames)
-                .RuleFor(worker => worker.EmailAddress, emailAddress)
-                .RuleFor(worker => worker.SystemUserId, systemUserId);
+                .RuleFor(worker => worker.FirstNames, f => f.Random.String2(30))
+                .RuleFor(worker => worker.LastNames, f => f.Random.String2(30))
+                .RuleFor(worker => worker.EmailAddress, f => f.Person.Email)
+                .RuleFor(worker => worker.SystemUserId, f => f.Random.String2(10));
         }
 
         public static Visit CreateDatabaseVisit(
@@ -104,9 +104,10 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
             long? orgId = null,
             long? workerId = null,
             long? cpVisitScheduleStepId = null,
-            long? cpRegistrationId = null)
+            long? cpRegistrationId = null,
+            Worker? pWorker = null)
         {
-            Worker worker = CreateDatabaseWorker();
+            Worker worker = pWorker ?? CreateDatabaseWorker();
 
             Visit visit = new Faker<Visit>()
                 .RuleFor(v => v.VisitId, f => visitId ?? f.UniqueIndex)

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -67,9 +67,12 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
         }
 
         public static CaseNote CreateDatabaseCaseNote(long id = 123, long personId = 123, string noteType = "CASSUMASC",
-            string copiedBy = "CGYORFI", string createdBy = "CGYORFI", string updatedBy = "CGYORFI")
+            string copiedBy = "CGYORFI", string createdBy = "CGYORFI", string updatedBy = "CGYORFI", Worker? createdWorker = null,
+            Worker? updatedWorker = null, Worker? copiedWorker = null)
         {
             var faker = new Fixture();
+
+            createdWorker ??= TestHelper.CreateDatabaseWorker();
 
             return faker.Build<CaseNote>()
                 .With(caseNote => caseNote.Id, id)
@@ -78,6 +81,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .With(caseNote => caseNote.CreatedBy, createdBy)
                 .With(caseNote => caseNote.LastUpdatedBy, updatedBy)
                 .With(caseNote => caseNote.CopiedBy, copiedBy)
+                .With(caseNote => caseNote.CreatedByWorker, createdWorker)
                 .Create();
         }
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Infrastructure/SocialCareContextTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Infrastructure/SocialCareContextTests.cs
@@ -25,6 +25,9 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Infrastructure
         public void CanCreateADatabaseRecordForACaseNote()
         {
             var person = TestHelper.CreateDatabasePersonEntity();
+
+
+
             var caseNote = TestHelper.CreateDatabaseCaseNote(person.Id);
 
             SocialCareContext.Add(caseNote);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Infrastructure/SocialCareContextTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Infrastructure/SocialCareContextTests.cs
@@ -25,9 +25,6 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Infrastructure
         public void CanCreateADatabaseRecordForACaseNote()
         {
             var person = TestHelper.CreateDatabasePersonEntity();
-
-
-
             var caseNote = TestHelper.CreateDatabaseCaseNote(person.Id);
 
             SocialCareContext.Add(caseNote);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Infrastructure/SocialCareContextTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Infrastructure/SocialCareContextTests.cs
@@ -38,7 +38,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Infrastructure
         [Test]
         public void CanCreateADatabaseRecordForAVisit()
         {
-            var visit = TestHelper.CreateDatabaseVisit().Item1;
+            var visit = TestHelper.CreateDatabaseVisit();
 
             SocialCareContext.Add(visit);
             SocialCareContext.SaveChanges();

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllCaseNotesUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllCaseNotesUseCaseTests.cs
@@ -16,7 +16,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
     {
         private Mock<ISocialCareGateway> _mockSocialCareGateway;
         private GetAllCaseNotesUseCase _classUnderTest;
-        private Fixture _fixture = new Fixture();
+        private readonly Fixture _fixture = new Fixture();
 
         [SetUp]
         public void SetUp()
@@ -42,11 +42,11 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void ReturnsListOfSummarisedCaseNoteInformation()
         {
-            var stubbedCaseNotes = _fixture.CreateMany<CaseNoteInformation>();
+            var stubbedCaseNotes = _fixture.CreateMany<CaseNoteInformation>().ToList();
 
             _mockSocialCareGateway.Setup(x =>
                     x.GetAllCaseNotes(34567))
-                .Returns(stubbedCaseNotes.ToList());
+                .Returns(stubbedCaseNotes);
 
             var response = _classUnderTest.Execute(34567);
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllResidentsUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetAllResidentsUseCaseTests.cs
@@ -21,7 +21,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
     {
         private Mock<ISocialCareGateway> _mockMosaicGateway;
         private GetAllResidentsUseCase _classUnderTest;
-        private Fixture _fixture = new Fixture();
+        private readonly Fixture _fixture = new Fixture();
         private Mock<IValidatePostcode> _mockPostcodeValidator;
 
         [SetUp]
@@ -35,11 +35,11 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void ReturnsResidentInformationList()
         {
-            var stubbedResidents = _fixture.CreateMany<ResidentInformation>();
+            var stubbedResidents = _fixture.CreateMany<ResidentInformation>().ToList();
 
             _mockMosaicGateway.Setup(x =>
                     x.GetAllResidents(3, 15, null, "ciasom", "tessellate", null, "E8 1DY", "1 Montage street", "a"))
-                .Returns(stubbedResidents.ToList());
+                .Returns(stubbedResidents);
             var rqp = new ResidentQueryParam
             {
                 FirstName = "ciasom",
@@ -95,9 +95,9 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void ReturnsTheNextCursor()
         {
-            var stubbedResidents = _fixture.CreateMany<ResidentInformation>(10);
-            int idCount = 10;
-            foreach (ResidentInformation resident in stubbedResidents)
+            var stubbedResidents = _fixture.CreateMany<ResidentInformation>(10).ToList();
+            var idCount = 10;
+            foreach (var resident in stubbedResidents)
             {
                 idCount++;
                 resident.MosaicId = idCount.ToString();
@@ -106,7 +106,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
 
             _mockMosaicGateway.Setup(x =>
                     x.GetAllResidents(0, 10, null, null, null, null, null, null, null))
-                .Returns(stubbedResidents.ToList());
+                .Returns(stubbedResidents);
 
             _classUnderTest.Execute(new ResidentQueryParam(), 0, 10).NextCursor.Should().Be(expectedNextCursor);
         }

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetCaseNoteInformationByIdUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetCaseNoteInformationByIdUseCaseTests.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using AutoFixture;
 using FluentAssertions;
 using Moq;
@@ -16,7 +14,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
     {
         private Mock<ISocialCareGateway> _mockSocialCareGateway;
         private GetCaseNoteInformationByIdUseCase _classUnderTest;
-        private Fixture _fixture = new Fixture();
+        private readonly Fixture _fixture = new Fixture();
 
         [SetUp]
         public void SetUp()
@@ -28,8 +26,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void WhenThereIsNoMatchingCaseNote_ReturnsNull()
         {
-            CaseNoteInformation noMatchingCaseNote = null;
-            _mockSocialCareGateway.Setup(x => x.GetCaseNoteInformationById(123)).Returns(noMatchingCaseNote);
+            _mockSocialCareGateway.Setup(x => x.GetCaseNoteInformationById(123));
 
             var response = _classUnderTest.Execute(123);
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetEntityByIdUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetEntityByIdUseCaseTests.cs
@@ -46,7 +46,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         public void IfGatewayReturnsNullThrowNotFoundError()
         {
             _mockMosaicGateway.Setup(x => x.GetEntityById(It.IsAny<int>(), null));
-            
+
             Func<ResidentInformationResponse> testDelegate = () => _classUnderTest.Execute(1);
 
             testDelegate.Should().Throw<ResidentNotFoundException>();

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetEntityByIdUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetEntityByIdUseCaseTests.cs
@@ -45,9 +45,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void IfGatewayReturnsNullThrowNotFoundError()
         {
-            ResidentInformation nullResult = null;
-            _mockMosaicGateway.Setup(x => x.GetEntityById(It.IsAny<int>(), null))
-                .Returns(nullResult);
+            _mockMosaicGateway.Setup(x => x.GetEntityById(It.IsAny<int>(), null));
+            
             Func<ResidentInformationResponse> testDelegate = () => _classUnderTest.Execute(1);
 
             testDelegate.Should().Throw<ResidentNotFoundException>();

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetRelationshipsByPersonIdUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetRelationshipsByPersonIdUseCaseTests.cs
@@ -14,7 +14,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
     {
         private Mock<ISocialCareGateway> _mockSocialCareGateway;
         private GetRelationshipsByPersonIdUseCase _classUnderTest;
-        private Fixture _fixture = new Fixture();
+        private readonly Fixture _fixture = new Fixture();
 
         [SetUp]
         public void SetUp()
@@ -27,12 +27,12 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         public void WhenThereAreNoPersonalRelationships_ReturnsEmptyLists()
         {
             var request = new GetRelationshipsRequest() { PersonId = 123456789 };
-            PersonalRelationships noMatchingRelationships = new PersonalRelationships();
+            var noMatchingRelationships = new PersonalRelationships();
             _mockSocialCareGateway.Setup(x => x.GetPersonalRelationships(It.IsAny<long>())).Returns(noMatchingRelationships);
 
             var response = _classUnderTest.Execute(request);
 
-            response.PersonId.Equals(request.PersonId);
+            response.PersonId.Should().Be(request.PersonId);
 
             response.PersonalRelationships.Parents.Should().BeEmpty();
             response.PersonalRelationships.Siblings.Should().BeEmpty();
@@ -44,12 +44,12 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         public void WhenThereArePersonalRelationships_ReturnsListOfIDs()
         {
             var request = new GetRelationshipsRequest() { PersonId = 123456789 };
-            PersonalRelationships matchingRelationships = _fixture.Create<PersonalRelationships>();
+            var matchingRelationships = _fixture.Create<PersonalRelationships>();
             _mockSocialCareGateway.Setup(x => x.GetPersonalRelationships(It.IsAny<long>())).Returns(matchingRelationships);
 
             var response = _classUnderTest.Execute(request);
 
-            response.PersonId.Equals(request.PersonId);
+            response.PersonId.Should().Be(request.PersonId);
 
             response.PersonalRelationships.Parents.Should().NotBeEmpty();
             response.PersonalRelationships.Siblings.Should().NotBeEmpty();
@@ -66,7 +66,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
 
             var response = _classUnderTest.Execute(request);
 
-            response.PersonId.Equals(request.PersonId);
+            response.PersonId.Should().Be(request.PersonId);
 
             response.PersonalRelationships.Parents.Should().Equal(matchingRelationships.Parents);
             response.PersonalRelationships.Siblings.Should().Equal(matchingRelationships.Siblings);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetResidentRecordsUseCaseTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetResidentRecordsUseCaseTests.cs
@@ -44,7 +44,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         public void WhenThereIsVisits_ReturnListWithVisits()
         {
             const long fakePersonId = 123L;
-            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse();
+            var visit = TestHelper.CreateDatabaseVisit().ToDomain().ToResponse();
             var visits = new List<VisitInformation> { visit };
             var caseNotes = new CaseNoteInformationList { CaseNotes = new List<CaseNoteInformation>() };
             _mockGetVisitInformationByPersonId.Setup(x => x.Execute(fakePersonId)).Returns(visits);
@@ -76,7 +76,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         public void WhenThereIsCaseNotesAndVisits_ReturnListWithBoth()
         {
             const long fakePersonId = 123L;
-            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain().ToResponse();
+            var visit = TestHelper.CreateDatabaseVisit().ToDomain().ToResponse();
             var visits = new List<VisitInformation> { visit };
             var caseNote = TestHelper.CreateDatabaseCaseNote().ToDomain().ToResponse();
             var caseNotes = new CaseNoteInformationList { CaseNotes = new List<CaseNoteInformation> { caseNote } };

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetVisitInformationByPersonIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetVisitInformationByPersonIdTests.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 using ResidentsSocialCarePlatformApi.V1.Domain;
 using ResidentsSocialCarePlatformApi.V1.Factories;
 using ResidentsSocialCarePlatformApi.V1.Gateways;
-using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 using ResidentsSocialCarePlatformApi.V1.UseCase;
 
 namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
@@ -29,12 +28,11 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void IfNoMatchingRecords_ReturnsAnEmptyResponse()
         {
-            var noRecords = new List<VisitInformation>();
             const long fakePersonId = 34567L;
 
             _mockSocialCareGateway
                 .Setup(x => x.GetVisitInformationByPersonId(fakePersonId))
-                .Returns(noRecords);
+                .Returns(new List<VisitInformation>());
 
             var response = _classUnderTest.Execute(fakePersonId);
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetVisitInformationByVisitIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/UseCase/GetVisitInformationByVisitIdTests.cs
@@ -2,7 +2,6 @@ using FluentAssertions;
 using Moq;
 using NUnit.Framework;
 using ResidentsSocialCarePlatformApi.Tests.V1.Helper;
-using ResidentsSocialCarePlatformApi.V1.Domain;
 using ResidentsSocialCarePlatformApi.V1.Factories;
 using ResidentsSocialCarePlatformApi.V1.Gateways;
 using ResidentsSocialCarePlatformApi.V1.UseCase;
@@ -25,9 +24,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void WhenThereIsNoMatchingVisit_ReturnsNull()
         {
-            VisitInformation? noVisit = null;
             const long fakeVisitId = 123L;
-            _mockSocialCareGateway.Setup(x => x.GetVisitInformationByVisitId(fakeVisitId)).Returns(noVisit);
+            _mockSocialCareGateway.Setup(x => x.GetVisitInformationByVisitId(fakeVisitId));
 
             var response = _classUnderTest.Execute(fakeVisitId);
 
@@ -37,7 +35,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.UseCase
         [Test]
         public void WhenThereIsAMatchingVisit_ReturnsVisit()
         {
-            var visit = TestHelper.CreateDatabaseVisit().Item1.ToDomain();
+            var visit = TestHelper.CreateDatabaseVisit().ToDomain();
             _mockSocialCareGateway.Setup(x => x.GetVisitInformationByVisitId(visit.VisitId)).Returns(visit);
 
             var response = _classUnderTest.Execute(visit.VisitId);

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/CaseNoteInformation.cs
@@ -5,43 +5,12 @@ namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
     public class CaseNoteInformation
     {
         public string MosaicId { get; set; }
-
-        public long CaseNoteId { get; set; }
-
-        public long? PersonVisitId { get; set; }
-
-        public string NoteType { get; set; }
-
+        public string CaseNoteId { get; set; }
         public string CaseNoteTitle { get; set; }
-
-        public string EffectiveDate { get; set; }
-
-        public string CreatedOn { get; set; }
-
-        public string LastUpdatedOn { get; set; }
-
-        public string CreatedByName { get; set; }
-
-        public string CreatedByEmail { get; set; }
-
-        public string LastUpdatedName { get; set; }
-
-        public string LastUpdatedEmail { get; set; }
-
         public string CaseNoteContent { get; set; }
-
-        public long? RootCaseNoteId { get; set; }
-
-        public string CompletedDate { get; set; }
-
-        public string TimeoutDate { get; set; }
-
-        public long? CopyOfCaseNoteId { get; set; }
-
-        public string CopiedByName { get; set; }
-
-        public string CopiedByEmail { get; set; }
-
-        public string CopiedDate { get; set; }
+        public string CreatedOn { get; set; }
+        public string CreatedByEmail { get; set; }
+        public string CreatedByName { get; set; }
+        public string NoteType { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Domain/CaseNoteInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Domain/CaseNoteInformation.cs
@@ -5,43 +5,12 @@ namespace ResidentsSocialCarePlatformApi.V1.Domain
     public class CaseNoteInformation
     {
         public string MosaicId { get; set; }
-
         public long CaseNoteId { get; set; }
-
-        public long? PersonVisitId { get; set; }
-
-        public string NoteType { get; set; }
-
         public string CaseNoteTitle { get; set; }
-
-        public DateTime? EffectiveDate { get; set; }
-
-        public DateTime? CreatedOn { get; set; }
-
-        public DateTime? LastUpdatedOn { get; set; }
-
-        public string CreatedByName { get; set; }
-
-        public string CreatedByEmail { get; set; }
-
-        public string LastUpdatedName { get; set; }
-
-        public string LastUpdatedEmail { get; set; }
-
         public string CaseNoteContent { get; set; }
-
-        public long? RootCaseNoteId { get; set; }
-
-        public DateTime? CompletedDate { get; set; }
-
-        public DateTime? TimeoutDate { get; set; }
-
-        public long? CopyOfCaseNoteId { get; set; }
-
-        public string CopiedByName { get; set; }
-
-        public string CopiedByEmail { get; set; }
-
-        public DateTime? CopiedDate { get; set; }
+        public DateTime? CreatedOn { get; set; }
+        public string CreatedByEmail { get; set; }
+        public string CreatedByName { get; set; }
+        public string NoteType { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Domain/VisitInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Domain/VisitInformation.cs
@@ -1,4 +1,6 @@
 using System;
+using ResidentsSocialCarePlatformApi.V1.Infrastructure;
+
 #nullable enable
 
 namespace ResidentsSocialCarePlatformApi.V1.Domain

--- a/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System.Linq;
 using ResidentsSocialCarePlatformApi.V1.Domain;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 using DbAddress = ResidentsSocialCarePlatformApi.V1.Infrastructure.Address;
@@ -8,9 +6,9 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
 {
     public static class EntityFactory
     {
-        public static Domain.ResidentInformation ToDomain(this Person databaseEntity)
+        public static ResidentInformation ToDomain(this Person databaseEntity)
         {
-            return new Domain.ResidentInformation
+            return new ResidentInformation
             {
                 MosaicId = databaseEntity.Id.ToString(),
                 FirstName = databaseEntity.FirstName,
@@ -22,10 +20,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 Gender = databaseEntity.Gender,
                 Restricted = databaseEntity.Restricted
             };
-        }
-        public static List<Domain.ResidentInformation> ToDomain(this IEnumerable<Person> people)
-        {
-            return people.Select(p => p.ToDomain()).ToList();
         }
 
         public static PhoneNumber ToDomain(this TelephoneNumber number)
@@ -66,7 +60,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
 
         public static VisitInformation ToDomain(this Visit visit)
         {
-
             return new VisitInformation
             {
                 VisitId = visit.VisitId,

--- a/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
@@ -54,7 +54,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 CreatedByEmail = caseNote.Worker.EmailAddress,
                 CreatedByName = $"{caseNote.Worker.FirstNames} {caseNote.Worker.LastNames}",
                 CreatedOn = caseNote.CreatedOn,
-                NoteType = caseNote.NoteType
+                NoteType = caseNote.NoteTypeDescription?.Description
             };
         }
 

--- a/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
@@ -56,22 +56,11 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 MosaicId = caseNote.PersonId.ToString(),
                 CaseNoteId = caseNote.Id,
                 CaseNoteTitle = caseNote.Title,
-                CreatedOn = caseNote.CreatedOn,
-                PersonVisitId = caseNote.PersonVisitId,
                 CaseNoteContent = caseNote.Note,
-                RootCaseNoteId = caseNote.RootCaseNoteId,
-                EffectiveDate = caseNote.EffectiveDate,
-                LastUpdatedOn = caseNote.LastUpdatedOn,
-                CompletedDate = caseNote.CompletedDate,
-                TimeoutDate = caseNote.TimeoutDate,
-                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
-                CopiedDate = caseNote.CopiedDate,
-                CreatedByEmail = caseNote.createdByWorker.EmailAddress,
-                CreatedByName = $"{caseNote.createdByWorker.FirstNames} {caseNote.createdByWorker.LastNames}",
-                LastUpdatedEmail = caseNote.lastUpdatedWorker.EmailAddress,
-                LastUpdatedName = $"{caseNote.lastUpdatedWorker.FirstNames} {caseNote.lastUpdatedWorker.LastNames}",
-                CopiedByEmail = caseNote.copiedByWorker.EmailAddress,
-                CopiedByName = $"{caseNote.copiedByWorker.FirstNames} {caseNote.copiedByWorker.LastNames}"
+                CreatedByEmail = caseNote.CreatedByWorker.EmailAddress,
+                CreatedByName = $"{caseNote.CreatedByWorker.FirstNames} {caseNote.CreatedByWorker.LastNames}",
+                CreatedOn = caseNote.CreatedOn,
+                NoteType = caseNote.NoteType
             };
         }
 

--- a/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
@@ -86,7 +86,9 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 CpRegistrationId = visit.CpRegistrationId,
                 CpVisitScheduleStepId = visit.CpVisitScheduleStepId,
                 CpVisitScheduleDays = visit.CpVisitScheduleDays,
-                CpVisitOnTime = visit.CpVisitOnTime
+                CpVisitOnTime = visit.CpVisitOnTime,
+                CreatedByEmail = visit.Worker.EmailAddress,
+                CreatedByName = $"{visit.Worker.FirstNames} {visit.Worker.LastNames}"
             };
         }
     }

--- a/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
@@ -66,12 +66,12 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 TimeoutDate = caseNote.TimeoutDate,
                 CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
                 CopiedDate = caseNote.CopiedDate,
-                CreatedByEmail = caseNote.createdByWorker.EmailAddress,
-                CreatedByName = $"{caseNote.createdByWorker.FirstNames} {caseNote.createdByWorker.LastNames}",
-                LastUpdatedEmail = caseNote.lastUpdatedWorker.EmailAddress,
-                LastUpdatedName = $"{caseNote.lastUpdatedWorker.FirstNames} {caseNote.lastUpdatedWorker.LastNames}",
-                CopiedByEmail = caseNote.copiedByWorker.EmailAddress,
-                CopiedByName = $"{caseNote.copiedByWorker.FirstNames} {caseNote.copiedByWorker.LastNames}"
+                CreatedByEmail = caseNote.CreatedByWorker.EmailAddress,
+                CreatedByName = $"{caseNote.CreatedByWorker.FirstNames} {caseNote.CreatedByWorker.LastNames}",
+                LastUpdatedEmail = caseNote.LastUpdatedWorker.EmailAddress,
+                LastUpdatedName = $"{caseNote.LastUpdatedWorker.FirstNames} {caseNote.LastUpdatedWorker.LastNames}",
+                CopiedByEmail = caseNote.CopiedByWorker.EmailAddress,
+                CopiedByName = $"{caseNote.CopiedByWorker.FirstNames} {caseNote.CopiedByWorker.LastNames}"
             };
         }
 

--- a/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
@@ -65,7 +65,13 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 CompletedDate = caseNote.CompletedDate,
                 TimeoutDate = caseNote.TimeoutDate,
                 CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
-                CopiedDate = caseNote.CopiedDate
+                CopiedDate = caseNote.CopiedDate,
+                CreatedByEmail = caseNote.createdByWorker.EmailAddress,
+                CreatedByName = $"{caseNote.createdByWorker.FirstNames} {caseNote.createdByWorker.LastNames}",
+                LastUpdatedEmail = caseNote.lastUpdatedWorker.EmailAddress,
+                LastUpdatedName = $"{caseNote.lastUpdatedWorker.FirstNames} {caseNote.lastUpdatedWorker.LastNames}",
+                CopiedByEmail = caseNote.copiedByWorker.EmailAddress,
+                CopiedByName = $"{caseNote.copiedByWorker.FirstNames} {caseNote.copiedByWorker.LastNames}"
             };
         }
 

--- a/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/EntityFactory.cs
@@ -51,8 +51,8 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 CaseNoteId = caseNote.Id,
                 CaseNoteTitle = caseNote.Title,
                 CaseNoteContent = caseNote.Note,
-                CreatedByEmail = caseNote.CreatedByWorker.EmailAddress,
-                CreatedByName = $"{caseNote.CreatedByWorker.FirstNames} {caseNote.CreatedByWorker.LastNames}",
+                CreatedByEmail = caseNote.Worker.EmailAddress,
+                CreatedByName = $"{caseNote.Worker.FirstNames} {caseNote.Worker.LastNames}",
                 CreatedOn = caseNote.CreatedOn,
                 NoteType = caseNote.NoteType
             };

--- a/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
@@ -2,7 +2,6 @@ using System.Collections.Generic;
 using System.Linq;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
 using ResidentsSocialCarePlatformApi.V1.Domain;
-using ResidentsSocialCarePlatformApi.V1.UseCase;
 
 namespace ResidentsSocialCarePlatformApi.V1.Factories
 {
@@ -37,25 +36,13 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
             return new Boundary.Responses.CaseNoteInformation
             {
                 MosaicId = caseNote.MosaicId,
-                CaseNoteId = caseNote.CaseNoteId,
+                CaseNoteId = caseNote.CaseNoteId.ToString(),
                 CaseNoteTitle = caseNote.CaseNoteTitle,
-                EffectiveDate = caseNote.EffectiveDate?.ToString("s"),
                 CreatedOn = caseNote.CreatedOn?.ToString("s"),
-                LastUpdatedOn = caseNote.LastUpdatedOn?.ToString("s"),
-                PersonVisitId = caseNote.PersonVisitId,
                 NoteType = caseNote.NoteType,
                 CreatedByName = caseNote.CreatedByName,
                 CreatedByEmail = caseNote.CreatedByEmail,
-                LastUpdatedName = caseNote.LastUpdatedName,
-                LastUpdatedEmail = caseNote.LastUpdatedEmail,
-                CaseNoteContent = caseNote.CaseNoteContent,
-                RootCaseNoteId = caseNote.RootCaseNoteId,
-                CompletedDate = caseNote.CompletedDate?.ToString("s"),
-                TimeoutDate = caseNote.TimeoutDate?.ToString("s"),
-                CopyOfCaseNoteId = caseNote.CopyOfCaseNoteId,
-                CopiedDate = caseNote.CopiedDate?.ToString("s"),
-                CopiedByName = caseNote.CopiedByName,
-                CopiedByEmail = caseNote.CopiedByEmail
+                CaseNoteContent = caseNote.CaseNoteContent
             };
         }
 
@@ -138,7 +125,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
         {
             return new ResidentHistoricRecordCaseNote
             {
-                RecordId = caseNote.CaseNoteId,
                 FormName = "",
                 PersonId = personId,
                 FirstName = "",
@@ -147,7 +133,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 OfficerEmail = caseNote.CreatedByEmail,
                 CaseFormUrl = "",
                 CaseFormTimeStamp = "",
-                DateOfEvent = caseNote.CompletedDate,
                 CaseNoteTitle = "",
                 RecordType = RecordType.CaseNote,
                 CaseNote = caseNote

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -87,9 +87,15 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
 
         public List<CaseNoteInformation> GetAllCaseNotes(long personId)
         {
-            var caseNotes = _socialCareContext.CaseNotes.Where(note => note.PersonId == personId).ToList();
+            var caseNotes = _socialCareContext.CaseNotes
+            .Where(note => note.PersonId == personId)
+            .Include(x => x.CreatedByWorker)
+            .Include(x => x.LastUpdatedWorker)
+            .Include(x => x.CopiedByWorker)
+            .Include(x => x.NewNoteType)
+            .ToList();
 
-            return caseNotes.Select(AddRelatedInformationToCaseNote).ToList();
+            return caseNotes.Select(x => x.ToDomain()).ToList();
         }
 
         public Domain.CaseNoteInformation GetCaseNoteInformationById(long caseNoteId)

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -89,7 +89,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
         {
             var caseNotes = _socialCareContext.CaseNotes
             .Where(note => note.PersonId == personId)
-            .Include(x => x.CreatedByWorker)
+            .Include(x => x.Worker)
             .ToList();
 
             return caseNotes.Select(x => x.ToDomain()).ToList();

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -90,48 +90,16 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
             var caseNotes = _socialCareContext.CaseNotes
             .Where(note => note.PersonId == personId)
             .Include(x => x.CreatedByWorker)
-            .Include(x => x.LastUpdatedWorker)
-            .Include(x => x.CopiedByWorker)
-            .Include(x => x.NewNoteType)
             .ToList();
 
             return caseNotes.Select(x => x.ToDomain()).ToList();
         }
 
-        public Domain.CaseNoteInformation GetCaseNoteInformationById(long caseNoteId)
+        public CaseNoteInformation? GetCaseNoteInformationById(long caseNoteId)
         {
             var caseNote = _socialCareContext.CaseNotes.FirstOrDefault(caseNote => caseNote.Id == caseNoteId);
 
-            if (caseNote == null) return null;
-
-            var caseNoteInformation = caseNote.ToDomain();
-
-            var noteType = _socialCareContext.NoteTypes.FirstOrDefault(noteType => noteType.Type == caseNote.NoteType);
-            caseNoteInformation.NoteType = noteType?.Description;
-
-            var createdByWorker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId == caseNote.CreatedBy);
-            if (createdByWorker != null)
-            {
-                caseNoteInformation.CreatedByName = $"{createdByWorker.FirstNames} {createdByWorker.LastNames}";
-                caseNoteInformation.CreatedByEmail = createdByWorker.EmailAddress;
-            }
-
-            var lastUpdatedByWorker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId == caseNote.LastUpdatedBy);
-            if (lastUpdatedByWorker != null)
-            {
-                caseNoteInformation.LastUpdatedName =
-                    $"{lastUpdatedByWorker.FirstNames} {lastUpdatedByWorker.LastNames}";
-                caseNoteInformation.LastUpdatedEmail = lastUpdatedByWorker.EmailAddress;
-            }
-
-            if (caseNote.CopiedBy != null)
-            {
-                var copiedByWorker = _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId == caseNote.CopiedBy);
-                caseNoteInformation.CopiedByName = $"{copiedByWorker.FirstNames} {copiedByWorker.LastNames}";
-                caseNoteInformation.CopiedByEmail = copiedByWorker.EmailAddress;
-            }
-
-            return caseNoteInformation;
+            return caseNote?.ToDomain();
         }
 
         public IEnumerable<VisitInformation?> GetVisitInformationByPersonId(long personId)
@@ -273,54 +241,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
         private static string GetSearchPattern(string str)
         {
             return $"%{str?.Replace(" ", "")}%";
-        }
-
-        private string LookUpNoteTypeDescription(string noteTypeCode)
-        {
-            return _socialCareContext.NoteTypes.FirstOrDefault(type => type.Type.Equals(noteTypeCode))?.Description;
-        }
-
-
-        private string? GetWorkerName(string? actionDoneById = null, long? workerId = null)
-        {
-            if (workerId != null)
-            {
-                var workerById = _socialCareContext.Workers.FirstOrDefault(w => w.Id.Equals(workerId));
-                return workerById != null ? $"{workerById.FirstNames} {workerById.LastNames}" : null;
-            }
-
-            var worker = _socialCareContext.Workers.FirstOrDefault(w => w.SystemUserId.Equals(actionDoneById));
-            return worker != null ? $"{worker.FirstNames} {worker.LastNames}" : null;
-        }
-
-        private string? GetWorkerEmailAddress(string? actionDoneById = null, long? workerId = null)
-        {
-            if (workerId != null)
-            {
-                return _socialCareContext.Workers.FirstOrDefault(worker => worker.Id.Equals(workerId))?.EmailAddress;
-            }
-
-            return _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId.Equals(actionDoneById))
-                ?.EmailAddress;
-        }
-
-        private CaseNoteInformation AddRelatedInformationToCaseNote(CaseNote caseNote)
-        {
-            var caseNoteInformation = caseNote.ToDomain();
-            caseNoteInformation.CaseNoteContent = null;
-
-            caseNoteInformation.NoteType = LookUpNoteTypeDescription(caseNote.NoteType);
-
-            caseNoteInformation.CreatedByName = GetWorkerName(caseNote.CreatedBy);
-            caseNoteInformation.CreatedByEmail = GetWorkerEmailAddress(caseNote.CreatedBy);
-
-            caseNoteInformation.LastUpdatedName = GetWorkerName(caseNote.LastUpdatedBy);
-            caseNoteInformation.LastUpdatedEmail = GetWorkerEmailAddress(caseNote.LastUpdatedBy);
-
-            caseNoteInformation.CopiedByName = GetWorkerName(caseNote.CopiedBy);
-            caseNoteInformation.CopiedByEmail = GetWorkerEmailAddress(caseNote.CopiedBy);
-
-            return caseNoteInformation;
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -132,16 +132,20 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
         {
             var visits = _socialCareContext.Visits
                 .Where(visit => visit.PersonId == personId)
+                .Include(x => x.Worker)
                 .ToList();
 
-            return visits.Select(AddRelatedInformationToVisit);
+            return visits.Select(x => x.ToDomain());
         }
 
         public VisitInformation? GetVisitInformationByVisitId(long visitId)
         {
-            var visitInformation = _socialCareContext.Visits.FirstOrDefault(visit => visit.VisitId == visitId);
+            var visitInformation = _socialCareContext
+                .Visits
+                .Include(x => x.Worker)
+                .FirstOrDefault(visit => visit.VisitId == visitId);
 
-            return AddRelatedInformationToVisit(visitInformation);
+            return visitInformation?.ToDomain();
         }
 
         public Domain.PersonalRelationships GetPersonalRelationships(long personId)
@@ -312,21 +316,5 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
 
             return caseNoteInformation;
         }
-
-        private VisitInformation? AddRelatedInformationToVisit(Visit? visit)
-        {
-            if (visit == null)
-            {
-                return null;
-            }
-
-            var visitDomain = visit.ToDomain();
-
-            visitDomain.CreatedByEmail = GetWorkerEmailAddress(workerId: visit.WorkerId);
-            visitDomain.CreatedByName = GetWorkerName(workerId: visit.WorkerId);
-
-            return visitDomain;
-        }
-
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -90,6 +90,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
             var caseNotes = _socialCareContext.CaseNotes
             .Where(note => note.PersonId == personId)
             .Include(x => x.Worker)
+            .Include(x => x.NoteTypeDescription)
             .ToList();
 
             return caseNotes.Select(x => x.ToDomain()).ToList();
@@ -97,7 +98,10 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
 
         public CaseNoteInformation? GetCaseNoteInformationById(long caseNoteId)
         {
-            var caseNote = _socialCareContext.CaseNotes.FirstOrDefault(caseNote => caseNote.Id == caseNoteId);
+            var caseNote = _socialCareContext.CaseNotes.Where(caseNote => caseNote.Id == caseNoteId)
+            .Include(x => x.Worker)
+            .Include(x => x.NoteTypeDescription)
+            .FirstOrDefault();
 
             return caseNote?.ToDomain();
         }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
@@ -74,12 +74,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         public DateTime? CopiedDate { get; set; }
 
         //nav props
+        [ForeignKey("system_user_id")]
         public Worker CreatedByWorker { get; set; }
-
-        public Worker LastUpdatedWorker { get; set; }
-
-        public Worker CopiedByWorker { get; set; }
-
-        public NoteType NewNoteType { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
@@ -74,7 +74,9 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         public DateTime? CopiedDate { get; set; }
 
         //nav props
-        [ForeignKey("SystemUserId")]
         public Worker Worker { get; set; }
+
+        [ForeignKey("NoteType")]
+        public NoteType NoteTypeDescription { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
@@ -74,6 +74,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         public DateTime? CopiedDate { get; set; }
 
         //nav props
+        [ForeignKey("SystemUserId")]
         public Worker Worker { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
@@ -74,6 +74,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         public DateTime? CopiedDate { get; set; }
 
         //nav props
-        public Worker CreatedByWorker { get; set; }
+        public Worker Worker { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
@@ -74,7 +74,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         public DateTime? CopiedDate { get; set; }
 
         //nav props
-        [ForeignKey("system_user_id")]
         public Worker CreatedByWorker { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
@@ -72,5 +72,14 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
 
         [Column("copied_date")]
         public DateTime? CopiedDate { get; set; }
+
+        //nav props
+        public Worker CreatedByWorker { get; set; }
+
+        public Worker LastUpdatedWorker { get; set; }
+
+        public Worker CopiedByWorker { get; set; }
+
+        public NoteType NewNoteType { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/SocialCareContext.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/SocialCareContext.cs
@@ -39,6 +39,13 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
             modelBuilder.Entity<PersonalRelationshipView>()
                 .ToView(name: "vw_personal_relationships", schema: "dbo")
                 .HasKey(p => p.PersonalRelationshipId);
+
+            modelBuilder.Entity<CaseNote>()
+            .HasOne(x => x.Worker)
+            .WithOne(x => x.CaseNote)
+            .HasPrincipalKey<CaseNote>(x => x.CreatedBy)
+            .HasForeignKey<Worker>(x => x.SystemUserId);
+
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Visit.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Visit.cs
@@ -68,5 +68,8 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         [Column("cp_visit_on_time")]
         [StringLength(1)]
         public string? CpVisitOnTime { get; set; }
+
+        //nav props
+        public Worker Worker { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Worker.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Worker.cs
@@ -34,5 +34,8 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         [Column("context_code")]
         [MaxLength(1)]
         public string ContextCode { get; set; }
+
+        // nav props
+        public CaseNote CaseNote { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/GetAllCaseNotesUseCase.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/GetAllCaseNotesUseCase.cs
@@ -7,7 +7,7 @@ namespace ResidentsSocialCarePlatformApi.V1.UseCase
 {
     public class GetAllCaseNotesUseCase : IGetAllCaseNotesUseCase
     {
-        private ISocialCareGateway _socialCareGateway;
+        private readonly ISocialCareGateway _socialCareGateway;
 
         public GetAllCaseNotesUseCase(ISocialCareGateway socialCareGateway)
         {

--- a/ResidentsSocialCarePlatformApi/V1/UseCase/GetVisitInformationByPersonId.cs
+++ b/ResidentsSocialCarePlatformApi/V1/UseCase/GetVisitInformationByPersonId.cs
@@ -9,7 +9,7 @@ namespace ResidentsSocialCarePlatformApi.V1.UseCase
 {
     public class GetVisitInformationByPersonId : IGetVisitInformationByPersonId
     {
-        private ISocialCareGateway _socialCareGateway;
+        private readonly ISocialCareGateway _socialCareGateway;
 
         public GetVisitInformationByPersonId(ISocialCareGateway socialCareGateway)
         {


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/secure/RapidBoard.jspa?rapidView=60&projectKey=SCT&modal=detail&selectedIssue=SCT-1124

## Describe this PR

### *What is the problem we're trying to solve*

This PR attempts to optimise the `ListCaseNotes` & `GetVisitInformation` endpoints to improve the response time for retrieving cases for a resident. The `ListCaseNotes` endpoint especially takes about 20 seconds before it gives back a response as it is essentially retrieves all case notes for a resident, loops over each individual one to add extra data for the response object by making extra database calls to the `Worker` & `NoteType` tables.

### *What changes have we introduced*
This PR adds navigation props to a visit and case note with these props being a `Worker` for both and a `NoteType` prop for just the case note object. The gateway now pulls all the needed data in one query rather than making multiple to help speed up the response time

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly

### *Follow up actions after merging PR*

