### PR TITLE
fix: Remove unused visit information

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactory/VisitInformation.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Factories/ResponseFactory/VisitInformation.cs
@@ -83,11 +83,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories.ResponseFactory
                     ReasonNotPlanned = "ReasonNotPlanned",
                     ReasonVisitNotMade = "ReasonVisitNotMade",
                     SeenAloneFlag = true,
-                    CompletedFlag = true,
-                    CpRegistrationId = 000L,
-                    CpVisitScheduleStepId = 000L,
-                    CpVisitScheduleDays = 000L,
-                    CpVisitOnTime = true
+                    CompletedFlag = true
                 },
                 new VisitInformationResponse
                 {
@@ -99,11 +95,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories.ResponseFactory
                     ReasonNotPlanned = null,
                     ReasonVisitNotMade = null,
                     SeenAloneFlag = false,
-                    CompletedFlag = false,
-                    CpRegistrationId = null,
-                    CpVisitScheduleStepId = null,
-                    CpVisitScheduleDays = null,
-                    CpVisitOnTime = false
+                    CompletedFlag = false
                 },
                 new VisitInformationResponse
                 {
@@ -115,11 +107,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Factories.ResponseFactory
                     ReasonNotPlanned = "ReasonNotPlanned",
                     ReasonVisitNotMade = "ReasonVisitNotMade",
                     SeenAloneFlag = false,
-                    CompletedFlag = false,
-                    CpRegistrationId = 000L,
-                    CpVisitScheduleStepId = 000L,
-                    CpVisitScheduleDays = 000L,
-                    CpVisitOnTime = false
+                    CompletedFlag = false
                 }
             };
 

--- a/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/VisitInformation.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Boundary/Responses/VisitInformation.cs
@@ -4,33 +4,15 @@ namespace ResidentsSocialCarePlatformApi.V1.Boundary.Responses
     public class VisitInformation
     {
         public long VisitId { get; set; }
-
         public long PersonId { get; set; }
-
         public string VisitType { get; set; } = null!;
-
         public string? PlannedDateTime { get; set; }
-
         public string? ActualDateTime { get; set; }
-
         public string? CreatedByName { get; set; }
-
         public string? CreatedByEmail { get; set; }
-
         public string? ReasonNotPlanned { get; set; }
-
         public string? ReasonVisitNotMade { get; set; }
-
         public bool SeenAloneFlag { get; set; }
-
         public bool CompletedFlag { get; set; }
-
-        public long? CpRegistrationId { get; set; }
-
-        public long? CpVisitScheduleStepId { get; set; }
-
-        public long? CpVisitScheduleDays { get; set; }
-
-        public bool CpVisitOnTime { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Factories/ResponseFactory.cs
@@ -92,10 +92,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Factories
                 ReasonVisitNotMade = visit.ReasonVisitNotMade,
                 SeenAloneFlag = !string.IsNullOrEmpty(visit.SeenAloneFlag) && visit.SeenAloneFlag.Equals("Y"),
                 CompletedFlag = !string.IsNullOrEmpty(visit.CompletedFlag) && visit.CompletedFlag.Equals("Y"),
-                CpRegistrationId = visit.CpRegistrationId,
-                CpVisitScheduleStepId = visit.CpVisitScheduleStepId,
-                CpVisitScheduleDays = visit.CpVisitScheduleDays,
-                CpVisitOnTime = !string.IsNullOrEmpty(visit.CpVisitOnTime) && visit.CpVisitOnTime.Equals("Y"),
                 CreatedByName = visit.CreatedByName,
                 CreatedByEmail = visit.CreatedByEmail
             };


### PR DESCRIPTION
Frontend never uses 4 of the properties from our historic visits so deleted them

CpRegistrationId
CpVisitScheduleStepId
CpVisitScheduleDays
CpVisitOnTime
