### PR TITLE
fix(SCT-1124): Associate Case Note with Worker and Remove Redundant Columns

### DIFF
--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -95,7 +95,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
         {
             var noteType = TestHelper.CreateDatabaseNoteType();
             var worker = TestHelper.CreateDatabaseWorker();
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, createdWorker: worker);
 
             socialCareContext.NoteTypes.Add(noteType);
             socialCareContext.Workers.Add(worker);
@@ -108,16 +108,16 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
                 CaseNoteTitle = caseNote.Title,
                 CreatedOn = caseNote.CreatedOn?.ToString("s"),
                 NoteType = noteType.Description,
-                CreatedByName = "Bow Archer",
+                CreatedByName = $"{worker.FirstNames} {worker.LastNames}",
                 CreatedByEmail = worker.EmailAddress,
                 CaseNoteContent = caseNote.Note,
                 CaseNoteId = caseNote.Id.ToString()
             };
         }
 
-        public static Visit AddVisitToDatabase(SocialCareContext socialCareContext, long? workerId = null)
+        public static Visit AddVisitToDatabase(SocialCareContext socialCareContext, Worker? worker = null)
         {
-            var visitInformation = TestHelper.CreateDatabaseVisit(workerId: workerId);
+            var visitInformation = TestHelper.CreateDatabaseVisit(worker: worker);
             socialCareContext.Visits.Add(visitInformation);
             socialCareContext.SaveChanges();
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/E2ETestHelpers.cs
@@ -1,9 +1,11 @@
 using System.Collections.Generic;
 using AutoFixture;
+using Bogus;
 using ResidentsSocialCarePlatformApi.Tests.V1.Helper;
 using ResidentsSocialCarePlatformApi.V1.Boundary.Responses;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 using Address = ResidentsSocialCarePlatformApi.V1.Boundary.Responses.Address;
+using Person = ResidentsSocialCarePlatformApi.V1.Infrastructure.Person;
 
 #nullable enable
 namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
@@ -59,22 +61,19 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
 
         public static CaseNoteInformation AddCaseNoteForASpecificPersonToDb(SocialCareContext context, long personId)
         {
-            var faker = new Fixture();
+            var fixture = new Fixture();
+            var faker = new Faker();
 
-            var noteTypeCode = faker.Create<NoteType>().Type;
-            var noteTypeDescription = faker.Create<NoteType>().Description;
+            var noteTypeCode = fixture.Create<NoteType>().Type;
+            var noteTypeDescription = fixture.Create<NoteType>().Description;
             var savedNoteType = TestHelper.CreateDatabaseNoteType(noteTypeCode, noteTypeDescription);
             context.NoteTypes.Add(savedNoteType);
-
-            var workerFirstName = faker.Create<Worker>().FirstNames;
-            var workerLastName = faker.Create<Worker>().LastNames;
-            var workerEmailAddress = faker.Create<Worker>().EmailAddress;
-            var workerSystemUserId = faker.Create<string>().Substring(0, 10);
-            var savedWorker = TestHelper.CreateDatabaseWorker(workerFirstName, workerLastName, workerEmailAddress, workerSystemUserId);
+            var savedWorker = TestHelper.CreateDatabaseWorker();
             context.Workers.Add(savedWorker);
 
-            var caseNoteId = faker.Create<CaseNote>().Id;
-            var savedCaseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, savedNoteType.Type, savedWorker.SystemUserId, savedWorker.SystemUserId, savedWorker.SystemUserId);
+
+            var caseNoteId = faker.Random.Long(min: 1);
+            var savedCaseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, savedNoteType.Type, savedWorker);
 
 
             context.CaseNotes.Add(savedCaseNote);
@@ -83,20 +82,20 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
             return new CaseNoteInformation
             {
                 MosaicId = savedCaseNote.PersonId.ToString(),
+                CaseNoteId = savedCaseNote.Id.ToString(),
                 NoteType = savedNoteType.Description,
                 CaseNoteTitle = savedCaseNote.Title,
                 CreatedOn = savedCaseNote.CreatedOn?.ToString("s"),
-                CreatedByName = $"{workerFirstName} {workerLastName}",
-                CreatedByEmail = workerEmailAddress,
-                CaseNoteId = savedCaseNote.Id.ToString()
+                CreatedByName = $"{savedWorker.FirstNames} {savedWorker.LastNames}",
+                CreatedByEmail = savedWorker.EmailAddress
             };
         }
 
         public static CaseNoteInformation AddCaseNoteWithNoteTypeAndWorkerToDatabase(SocialCareContext socialCareContext)
         {
             var noteType = TestHelper.CreateDatabaseNoteType();
-            var worker = TestHelper.CreateDatabaseWorker(firstNames: "Bow", lastNames: "Archer");
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, createdBy: worker.SystemUserId, updatedBy: worker.SystemUserId, copiedBy: worker.SystemUserId);
+            var worker = TestHelper.CreateDatabaseWorker();
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type);
 
             socialCareContext.NoteTypes.Add(noteType);
             socialCareContext.Workers.Add(worker);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByPersonIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByPersonIdTests.cs
@@ -16,7 +16,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
         public async Task WhenThereIsAVisitWithMatchingPersonId_Returns200AndVisitInformation()
         {
             var worker = E2ETestHelpers.AddWorkerToDatabase(SocialCareContext);
-            var visitInformation = E2ETestHelpers.AddVisitToDatabase(SocialCareContext, worker.Id).ToDomain().ToResponse();
+            var visitInformation = E2ETestHelpers.AddVisitToDatabase(SocialCareContext, worker).ToDomain().ToResponse();
             visitInformation.CreatedByEmail = worker.EmailAddress;
             visitInformation.CreatedByName = $"{worker.FirstNames} {worker.LastNames}";
             var uri = new Uri($"api/v1/residents/{visitInformation.PersonId}/visits", UriKind.Relative);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByVisitIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/GetVisitInformationByVisitIdTests.cs
@@ -15,7 +15,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
         public async Task WhenThereIsAVisitId_Returns200AndVisitInformation()
         {
             var worker = E2ETestHelpers.AddWorkerToDatabase(SocialCareContext);
-            var visit = E2ETestHelpers.AddVisitToDatabase(SocialCareContext, worker.Id).ToDomain().ToResponse();
+            var visit = E2ETestHelpers.AddVisitToDatabase(SocialCareContext, worker).ToDomain().ToResponse();
             visit.CreatedByEmail = worker.EmailAddress;
             visit.CreatedByName = $"{worker.FirstNames} {worker.LastNames}";
             var uri = new Uri($"api/v1/visits/{visit.VisitId}", UriKind.Relative);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/ListCaseNotesForAPerson.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/E2ETests/ListCaseNotesForAPerson.cs
@@ -13,7 +13,6 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.E2ETests
         [Test]
         public async Task ReturnsAllCaseNotesForASpecificPerson()
         {
-
             var person = E2ETestHelpers.AddPersonToDatabase(SocialCareContext);
 
             var expectedCaseNoteResponseOne = E2ETestHelpers.AddCaseNoteForASpecificPersonToDb(SocialCareContext, person.Id);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
@@ -71,11 +71,13 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         public void WhenThereIsAMatchingRecord_ReturnsDetailsFromWorkers()
         {
             const string workerEmailAddress = "adora@grayskull.com";
-            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase(copiedBy: "AGRAYSKULL", workerFirstNames: "Adora", workerLastNames: "Grayskull", workerEmailAddress: workerEmailAddress, workerSystemUserId: "AGRAYSKULL");
+            const string workerFirstName = "Foo";
+            const string workerLastname = "Bar";
+            var caseNote = AddCaseNoteWithNoteTypeAndWorkerToDatabase(workerFirstName, workerLastname, workerEmailAddress);
 
             var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
 
-            response?.CreatedByName.Should().Be("Adora Grayskull");
+            response?.CreatedByName.Should().Be($"{workerFirstName} {workerLastname}");
             response?.CreatedByEmail.Should().Be(workerEmailAddress);
         }
 
@@ -96,30 +98,13 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             response?.NoteType.Should().BeNull();
         }
 
-        [Test]
-        public void WhenCreatedByWorkerIsNull_ReturnsNullForCreatedByNameAndEmail()
-        {
-            var noteType = TestHelper.CreateDatabaseNoteType();
-            var worker = TestHelper.CreateDatabaseWorker();
-            var updatedByWorker = TestHelper.CreateDatabaseWorker();
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type);
-            SocialCareContext.NoteTypes.Add(noteType);
-            SocialCareContext.Workers.Add(worker);
-            SocialCareContext.Workers.Add(updatedByWorker);
-            SocialCareContext.CaseNotes.Add(caseNote);
-            SocialCareContext.SaveChanges();
-
-            var response = _classUnderTest.GetCaseNoteInformationById(caseNote.Id);
-
-            response?.CreatedByEmail.Should().BeNull();
-            response?.CreatedByName.Should().BeNull();
-        }
-
-        private CaseNote AddCaseNoteWithNoteTypeAndWorkerToDatabase(long id = 123, long personId = 123, string caseNoteType = "CASSUMASC", string caseNoteTypeDescription = "Case Summary (ASC)", string copiedBy = "CGYORFI", string workerFirstNames = "Csaba", string workerLastNames = "Gyorfi", string workerEmailAddress = "cgyorfi@email.com", string workerSystemUserId = "CGYORFI")
+        private CaseNote AddCaseNoteWithNoteTypeAndWorkerToDatabase(string workerFirstName = null, string workerLastName = null,
+            string workerEmailAddress = null, long id = 123, long personId = 123, string caseNoteType = "CASSUMASC",
+            string caseNoteTypeDescription = "Case Summary (ASC)")
         {
             var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);
-            var worker = TestHelper.CreateDatabaseWorker();
-            var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type);
+            var worker = TestHelper.CreateDatabaseWorker(workerFirstName, workerLastName, workerEmailAddress);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type, worker);
 
             SocialCareContext.NoteTypes.Add(noteType);
             SocialCareContext.Workers.Add(worker);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNoteInformationByIdTests.cs
@@ -100,9 +100,9 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         public void WhenCreatedByWorkerIsNull_ReturnsNullForCreatedByNameAndEmail()
         {
             var noteType = TestHelper.CreateDatabaseNoteType();
-            var worker = TestHelper.CreateDatabaseWorker(systemUserId: "existingUser");
+            var worker = TestHelper.CreateDatabaseWorker();
             var updatedByWorker = TestHelper.CreateDatabaseWorker();
-            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type, createdBy: "nonExistingUser");
+            var caseNote = TestHelper.CreateDatabaseCaseNote(noteType: noteType.Type);
             SocialCareContext.NoteTypes.Add(noteType);
             SocialCareContext.Workers.Add(worker);
             SocialCareContext.Workers.Add(updatedByWorker);
@@ -118,8 +118,8 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
         private CaseNote AddCaseNoteWithNoteTypeAndWorkerToDatabase(long id = 123, long personId = 123, string caseNoteType = "CASSUMASC", string caseNoteTypeDescription = "Case Summary (ASC)", string copiedBy = "CGYORFI", string workerFirstNames = "Csaba", string workerLastNames = "Gyorfi", string workerEmailAddress = "cgyorfi@email.com", string workerSystemUserId = "CGYORFI")
         {
             var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);
-            var worker = TestHelper.CreateDatabaseWorker(workerFirstNames, workerLastNames, workerEmailAddress, workerSystemUserId);
-            var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type, copiedBy, worker.SystemUserId, worker.SystemUserId);
+            var worker = TestHelper.CreateDatabaseWorker();
+            var caseNote = TestHelper.CreateDatabaseCaseNote(id, personId, noteType.Type);
 
             SocialCareContext.NoteTypes.Add(noteType);
             SocialCareContext.Workers.Add(worker);

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
@@ -104,7 +104,7 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             var worker = TestHelper.CreateDatabaseWorker();
             SocialCareContext.Workers.Add(worker);
 
-            var caseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, noteType.Type);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, noteType.Type, worker);
             SocialCareContext.CaseNotes.Add(caseNote);
 
             SocialCareContext.SaveChanges();

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Gateways/SocialCare/GetCaseNotesTests.cs
@@ -101,14 +101,10 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Gateways.SocialCare
             var noteType = TestHelper.CreateDatabaseNoteType(caseNoteType, caseNoteTypeDescription);
             SocialCareContext.NoteTypes.Add(noteType);
 
-            var workerFirstNames = faker.Create<Worker>().FirstNames;
-            var workerLastNames = faker.Create<Worker>().LastNames;
-            var workerEmailAddress = faker.Create<Worker>().EmailAddress;
-            var workerSystemUserId = faker.Create<string>().Substring(0, 10);
-            var worker = TestHelper.CreateDatabaseWorker(workerFirstNames, workerLastNames, workerEmailAddress, workerSystemUserId);
+            var worker = TestHelper.CreateDatabaseWorker();
             SocialCareContext.Workers.Add(worker);
 
-            var caseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, noteType.Type, workerSystemUserId, workerSystemUserId, workerSystemUserId);
+            var caseNote = TestHelper.CreateDatabaseCaseNote(caseNoteId, personId, noteType.Type);
             SocialCareContext.CaseNotes.Add(caseNote);
 
             SocialCareContext.SaveChanges();

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -64,17 +64,16 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
         }
 
         public static CaseNote CreateDatabaseCaseNote(long id = 123, long personId = 123, string noteType = "CASSUMASC",
-            string copiedBy = "CGYORFI", string createdBy = "CGYORFI", string updatedBy = "CGYORFI")
+            Worker? createdWorker = null)
         {
-            var faker = new Fixture();
+            createdWorker ??= CreateDatabaseWorker();
 
-            return faker.Build<CaseNote>()
-                .With(caseNote => caseNote.Id, id)
-                .With(caseNote => caseNote.PersonId, personId)
-                .With(caseNote => caseNote.NoteType, noteType)
-                .With(caseNote => caseNote.CreatedBy, createdBy)
-                .With(caseNote => caseNote.LastUpdatedBy, updatedBy)
-                .Create();
+            return new Faker<CaseNote>()
+                .RuleFor(caseNote => caseNote.Id, id)
+                .RuleFor(caseNote => caseNote.PersonId, personId)
+                .RuleFor(caseNote => caseNote.NoteType, noteType)
+                .RuleFor(caseNote => caseNote.CreatedBy, createdWorker.SystemUserId)
+                .RuleFor(caseNote => caseNote.CreatedByWorker, createdWorker);
         }
 
         public static NoteType CreateDatabaseNoteType(string noteType = "CASSUMASC", string description = "Case Summary (ASC)")
@@ -87,14 +86,14 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .Create();
         }
 
-        public static Worker CreateDatabaseWorker(string firstNames = "Csaba", string lastNames = "Gyorfi", string emailAddress = "cgyorfi@email.com", string systemUserId = "CGYORFI")
+        public static Worker CreateDatabaseWorker()
         {
             return new Faker<Worker>()
                 .RuleFor(worker => worker.Id, f => f.UniqueIndex)
-                .RuleFor(worker => worker.FirstNames, firstNames)
-                .RuleFor(worker => worker.LastNames, lastNames)
-                .RuleFor(worker => worker.EmailAddress, emailAddress)
-                .RuleFor(worker => worker.SystemUserId, systemUserId);
+                .RuleFor(worker => worker.FirstNames, f => f.Random.String2(30))
+                .RuleFor(worker => worker.LastNames, f => f.Random.String2(30))
+                .RuleFor(worker => worker.EmailAddress, f => f.Person.Email)
+                .RuleFor(worker => worker.SystemUserId, f => f.Random.String2(10));
         }
 
         public static Visit CreateDatabaseVisit(

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -74,7 +74,6 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .With(caseNote => caseNote.NoteType, noteType)
                 .With(caseNote => caseNote.CreatedBy, createdBy)
                 .With(caseNote => caseNote.LastUpdatedBy, updatedBy)
-                .With(caseNote => caseNote.CopiedBy, copiedBy)
                 .Create();
         }
 

--- a/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
+++ b/ResidentsSocialCarePlatformApi.Tests/V1/Helper/TestHelper.cs
@@ -86,13 +86,16 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
                 .Create();
         }
 
-        public static Worker CreateDatabaseWorker()
+        public static Worker CreateDatabaseWorker(
+            string? firstName = null,
+            string? lastName = null,
+            string? email = null)
         {
             return new Faker<Worker>()
                 .RuleFor(worker => worker.Id, f => f.UniqueIndex)
-                .RuleFor(worker => worker.FirstNames, f => f.Random.String2(30))
-                .RuleFor(worker => worker.LastNames, f => f.Random.String2(30))
-                .RuleFor(worker => worker.EmailAddress, f => f.Person.Email)
+                .RuleFor(worker => worker.FirstNames, f => firstName ?? f.Random.String2(30))
+                .RuleFor(worker => worker.LastNames, f => lastName ?? f.Random.String2(30))
+                .RuleFor(worker => worker.EmailAddress, f => email ?? f.Person.Email)
                 .RuleFor(worker => worker.SystemUserId, f => f.Random.String2(10));
         }
 
@@ -102,9 +105,10 @@ namespace ResidentsSocialCarePlatformApi.Tests.V1.Helper
             long? orgId = null,
             long? workerId = null,
             long? cpVisitScheduleStepId = null,
-            long? cpRegistrationId = null)
+            long? cpRegistrationId = null,
+            Worker? worker = null)
         {
-            Worker worker = CreateDatabaseWorker();
+            worker ??= CreateDatabaseWorker();
 
             Visit visit = new Faker<Visit>()
                 .RuleFor(v => v.VisitId, f => visitId ?? f.UniqueIndex)

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -240,37 +240,16 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
             return _socialCareContext.NoteTypes.FirstOrDefault(type => type.Type.Equals(noteTypeCode))?.Description;
         }
 
-
-        private string? GetWorkerName(string? actionDoneById = null, long? workerId = null)
-        {
-            if (workerId != null)
-            {
-                var workerById = _socialCareContext.Workers.FirstOrDefault(w => w.Id.Equals(workerId));
-                return workerById != null ? $"{workerById.FirstNames} {workerById.LastNames}" : null;
-            }
-
-            var worker = _socialCareContext.Workers.FirstOrDefault(w => w.SystemUserId.Equals(actionDoneById));
-            return worker != null ? $"{worker.FirstNames} {worker.LastNames}" : null;
-        }
-
-        private string? GetWorkerEmailAddress(string? actionDoneById = null, long? workerId = null)
-        {
-            if (workerId != null)
-            {
-                return _socialCareContext.Workers.FirstOrDefault(worker => worker.Id.Equals(workerId))?.EmailAddress;
-            }
-
-            return _socialCareContext.Workers.FirstOrDefault(worker => worker.SystemUserId.Equals(actionDoneById))
-                ?.EmailAddress;
-        }
-
         private CaseNoteInformation AddRelatedInformationToCaseNote(CaseNote caseNote)
         {
             var caseNoteInformation = caseNote.ToDomain();
             caseNoteInformation.CaseNoteContent = null;
             caseNoteInformation.NoteType = LookUpNoteTypeDescription(caseNote.NoteType);
-            caseNoteInformation.CreatedByName = GetWorkerName(caseNote.CreatedBy);
-            caseNoteInformation.CreatedByEmail = GetWorkerEmailAddress(caseNote.CreatedBy);
+
+            var worker = _socialCareContext.Workers.FirstOrDefault(w => w.SystemUserId.Equals(caseNote.CreatedBy));
+
+            caseNoteInformation.CreatedByName = worker != null ? $"{worker.FirstNames} {worker.LastNames}" : null;
+            caseNoteInformation.CreatedByEmail = worker?.EmailAddress;
 
             return caseNoteInformation;
         }

--- a/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Gateways/SocialCareGateway.cs
@@ -89,7 +89,10 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
 
         public List<CaseNoteInformation> GetAllCaseNotes(long personId)
         {
-            var caseNotes = _socialCareContext.CaseNotes.Where(note => note.PersonId == personId).ToList();
+            var caseNotes = _socialCareContext.CaseNotes
+                .Where(note => note.PersonId == personId)
+                .Include(x => x.CreatedByWorker)
+                .ToList();
 
             return caseNotes.Select(AddRelatedInformationToCaseNote).ToList();
         }
@@ -246,7 +249,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Gateways
             caseNoteInformation.CaseNoteContent = null;
             caseNoteInformation.NoteType = LookUpNoteTypeDescription(caseNote.NoteType);
 
-            var worker = _socialCareContext.Workers.FirstOrDefault(w => w.SystemUserId.Equals(caseNote.CreatedBy));
+            var worker = caseNote.CreatedByWorker;
 
             caseNoteInformation.CreatedByName = worker != null ? $"{worker.FirstNames} {worker.LastNames}" : null;
             caseNoteInformation.CreatedByEmail = worker?.EmailAddress;

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
@@ -30,6 +30,7 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         [Column("created_by")]
         [MaxLength(30)]
         public string CreatedBy { get; set; }
+        public Worker CreatedByWorker { get; set; }
 
         [Column("last_updated_by")]
         [MaxLength(30)]

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
@@ -37,9 +37,5 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
 
         [Column("note")]
         public string Note { get; set; }
-
-        [Column("copied_by")]
-        [MaxLength(30)]
-        public string CopiedBy { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/CaseNote.cs
@@ -16,10 +16,6 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         [MaxLength(9)]
         public long PersonId { get; set; }
 
-        [Column("person_visit_id")]
-        [MaxLength(9)]
-        public long? PersonVisitId { get; set; }
-
         [Column("note_type")]
         [MaxLength(16)]
         public string NoteType { get; set; }
@@ -28,14 +24,8 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         [MaxLength(100)]
         public string Title { get; set; }
 
-        [Column("effective_date")]
-        public DateTime? EffectiveDate { get; set; }
-
         [Column("created_on")]
         public DateTime? CreatedOn { get; set; }
-
-        [Column("last_updated_on")]
-        public DateTime? LastUpdatedOn { get; set; }
 
         [Column("created_by")]
         [MaxLength(30)]
@@ -48,29 +38,8 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         [Column("note")]
         public string Note { get; set; }
 
-        [Column("root_case_note")]
-        [MaxLength(9)]
-        public long? RootCaseNoteId { get; set; }
-
-        [Column("completed_date")]
-        public DateTime? CompletedDate { get; set; }
-
-        [Column("timeout_date")]
-        public DateTime? TimeoutDate { get; set; }
-
-        [Column("state")]
-        [MaxLength(16)]
-        public string State { get; set; }
-
-        [Column("copy_of_case_note_id")]
-        [MaxLength(9)]
-        public long? CopyOfCaseNoteId { get; set; }
-
         [Column("copied_by")]
         [MaxLength(30)]
         public string CopiedBy { get; set; }
-
-        [Column("copied_date")]
-        public DateTime? CopiedDate { get; set; }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922120305_MapWorkerToCaseNote.Designer.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922120305_MapWorkerToCaseNote.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
@@ -9,9 +10,10 @@ using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations
 {
     [DbContext(typeof(SocialCareContext))]
-    partial class SocialCareContextModelSnapshot : ModelSnapshot
+    [Migration("20210922110308_20210922120305_MapWorkerToCaseNote")]
+    partial class MapWorkerToCaseNote
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922120305_MapWorkerToCaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922120305_MapWorkerToCaseNote.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922120305_MapWorkerToCaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922120305_MapWorkerToCaseNote.cs
@@ -1,0 +1,152 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations
+{
+    public partial class MapWorkerToCaseNote : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "completed_date",
+                schema: "dbo",
+                table: "case_notes");
+
+            migrationBuilder.DropColumn(
+                name: "copied_date",
+                schema: "dbo",
+                table: "case_notes");
+
+            migrationBuilder.DropColumn(
+                name: "copy_of_case_note_id",
+                schema: "dbo",
+                table: "case_notes");
+
+            migrationBuilder.DropColumn(
+                name: "effective_date",
+                schema: "dbo",
+                table: "case_notes");
+
+            migrationBuilder.DropColumn(
+                name: "last_updated_on",
+                schema: "dbo",
+                table: "case_notes");
+
+            migrationBuilder.DropColumn(
+                name: "person_visit_id",
+                schema: "dbo",
+                table: "case_notes");
+
+            migrationBuilder.DropColumn(
+                name: "root_case_note",
+                schema: "dbo",
+                table: "case_notes");
+
+            migrationBuilder.DropColumn(
+                name: "state",
+                schema: "dbo",
+                table: "case_notes");
+
+            migrationBuilder.DropColumn(
+                name: "timeout_date",
+                schema: "dbo",
+                table: "case_notes");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_dm_visits_worker_id",
+                schema: "dbo",
+                table: "dm_visits",
+                column: "worker_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_dm_visits_workers_worker_id",
+                schema: "dbo",
+                table: "dm_visits",
+                column: "worker_id",
+                principalSchema: "dbo",
+                principalTable: "workers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_dm_visits_workers_worker_id",
+                schema: "dbo",
+                table: "dm_visits");
+
+            migrationBuilder.DropIndex(
+                name: "IX_dm_visits_worker_id",
+                schema: "dbo",
+                table: "dm_visits");
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "completed_date",
+                schema: "dbo",
+                table: "case_notes",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "copied_date",
+                schema: "dbo",
+                table: "case_notes",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "copy_of_case_note_id",
+                schema: "dbo",
+                table: "case_notes",
+                type: "bigint",
+                maxLength: 9,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "effective_date",
+                schema: "dbo",
+                table: "case_notes",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "last_updated_on",
+                schema: "dbo",
+                table: "case_notes",
+                type: "timestamp without time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "person_visit_id",
+                schema: "dbo",
+                table: "case_notes",
+                type: "bigint",
+                maxLength: 9,
+                nullable: true);
+
+            migrationBuilder.AddColumn<long>(
+                name: "root_case_note",
+                schema: "dbo",
+                table: "case_notes",
+                type: "bigint",
+                maxLength: 9,
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "state",
+                schema: "dbo",
+                table: "case_notes",
+                type: "character varying(16)",
+                maxLength: 16,
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "timeout_date",
+                schema: "dbo",
+                table: "case_notes",
+                type: "timestamp without time zone",
+                nullable: true);
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922230235_DropCopiedByColumnFromCaseNote.Designer.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922230235_DropCopiedByColumnFromCaseNote.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using ResidentsSocialCarePlatformApi.V1.Infrastructure;
@@ -9,9 +10,10 @@ using ResidentsSocialCarePlatformApi.V1.Infrastructure;
 namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations
 {
     [DbContext(typeof(SocialCareContext))]
-    partial class SocialCareContextModelSnapshot : ModelSnapshot
+    [Migration("20210922230235_DropCopiedByColumnFromCaseNote")]
+    partial class DropCopiedByColumnFromCaseNote
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922230235_DropCopiedByColumnFromCaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922230235_DropCopiedByColumnFromCaseNote.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations
 {

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922230235_DropCopiedByColumnFromCaseNote.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Migrations/20210922230235_DropCopiedByColumnFromCaseNote.cs
@@ -1,0 +1,26 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace ResidentsSocialCarePlatformApi.V1.Infrastructure.Migrations
+{
+    public partial class DropCopiedByColumnFromCaseNote : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "copied_by",
+                schema: "dbo",
+                table: "case_notes");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "copied_by",
+                schema: "dbo",
+                table: "case_notes",
+                type: "character varying(30)",
+                maxLength: 30,
+                nullable: true);
+        }
+    }
+}

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/SocialCareContext.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/SocialCareContext.cs
@@ -29,6 +29,12 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
                     telephoneNumber.Id,
                     telephoneNumber.PersonId
                 });
+
+            modelBuilder.Entity<CaseNote>()
+                .HasOne(caseNote => caseNote.CreatedByWorker)
+                .WithMany(worker => worker.CaseNotes)
+                .HasForeignKey(caseNote => caseNote.CreatedBy)
+                .HasPrincipalKey(worker => worker.SystemUserId);
         }
     }
 }

--- a/ResidentsSocialCarePlatformApi/V1/Infrastructure/Worker.cs
+++ b/ResidentsSocialCarePlatformApi/V1/Infrastructure/Worker.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 
@@ -22,6 +23,8 @@ namespace ResidentsSocialCarePlatformApi.V1.Infrastructure
         [Column("system_user_id")]
         [MaxLength(64)]
         public string SystemUserId { get; set; }
+
+        public List<CaseNote> CaseNotes { get; set; }
 
         [Column("email_address")]
         [MaxLength(240)]

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,1 +1,1 @@
-FROM postgres:12
+FROM postgres:12-buster


### PR DESCRIPTION
## Link to JIRA ticket

[/Cases API endpoint has a very long response time](https://hackney.atlassian.net/browse/SCT-1124)

## Describe this PR

### *What is the problem we're trying to solve*

Improve performance for getting historic case notes.
Currently using a for loop of database connections to get the worker associated with all of the case note's for a resident.

### *What changes have we introduced*

Introduced one to many relationship where a worker has many case notes and the case note has a foreign key that associates the case note with the worker.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Are there any next steps that need to addressed after merging this PR? Add them here.
